### PR TITLE
Fix SafeUpdate for JSONB columns; add CAS sentinel errors

### DIFF
--- a/lib/db/AGENTS.md
+++ b/lib/db/AGENTS.md
@@ -113,12 +113,16 @@ Simple modulo distribution using CRC32 checksum. This provides:
 **Important**: Resharding is NOT supported. Changing shard count requires data migration.
 
 ### Connection Management
-[database.go:66-93](database.go#L66-L93)
 
-- `dbs map[Vault]map[Tenant][]*sql.DB`: Global connection registry
-- `Open()`: Lazy initialization, idempotent (checks if `dbs != nil`)
-- `Close()`: Closes all connections, sets `dbs = nil`
-- Connections are opened from config at `configKeyDatabase = "database"`
+- `dbs map[Vault]map[Tenant][]engineDB`: Global connection registry. Each
+  `engineDB` pairs a `*sql.DB` with its `Engine` so dialect-aware primitives
+  (notably `SafeUpdate`'s lock clause) can pick the right SQL fragment.
+- Public `DBs(vault, tenant) ([]*sql.DB, error)` projects to `*sql.DB` only —
+  signature is preserved for downstream callers. Engine-aware access is
+  internal-only via `dbByShardKeyWithEngine`.
+- `Open()`: Lazy initialization, idempotent (guarded by `sync.Once`).
+- `Close()`: Closes all connections, sets `dbs = nil`, resets the once-guard.
+- Connections are opened from config at `configKeyDatabase = "database"`.
 
 ### Configuration Loading
 [database.go:74](database.go#L74)
@@ -270,20 +274,49 @@ for _, compute := range tos.compute {
 ### Locking Mechanisms
 
 #### Optimistic Locking (SafeUpdate)
-[update.go:127](update.go#L127)
 
 ```go
-row := tx.QueryRow(`SELECT "object", md5("object"), ...
-    FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1 FOR UPDATE NOWAIT`, fromKey.ID)
+row := tx.QueryRow(`SELECT "object", "created_at", ...
+    FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1`+lockClause, fromKey.ID)
 ```
 
-- Uses `FOR UPDATE NOWAIT` for row-level lock
-- Computes MD5 hash of current object
-- Compares `from` parameter with current state (line 149)
-- Update includes hash check in WHERE clause (line 165)
-- Returns error if object changed since read
+- Engine-aware lock clause: `FOR UPDATE NOWAIT` on Postgres, empty on SQLite
+  (the registry tracks `Engine` alongside each `*sql.DB`).
+- Scans the JSONB column into `[]byte`, then `json.Unmarshal` into `objT` — same
+  pattern as `SelectByID`. `database/sql` cannot `Scan` JSONB bytes directly
+  into a struct.
+- Comparator normalizes BOTH sides through the same `decode → compute-hook →
+  marshal` pipeline (with the just-loaded row metadata) before comparing:
+  the current row (`cmp`) and a clone of the caller's `from`. Comparing
+  Go-marshalled bytes on both sides avoids false-conflicts from Postgres JSONB
+  key-reordering / whitespace normalization, and running the compute hooks on
+  both sides makes the guard insensitive to embedded metadata (e.g. audit
+  stamps) that legitimately differs by load path and timestamp precision. Net:
+  the CAS guard compares **business state only**, so `from` may be loaded via
+  any path (`SelectByID`, `Process`, hand-built) without false-conflicting.
+  Trade-off: a write that only advances metadata (no business change) does not
+  trip the guard (no ABA-via-metadata detection).
+- Returns exported sentinels (`errors.Is`-friendly):
+  - `ErrObjectNotFound` when the row is missing.
+  - `ErrLockNotAvailable` when `FOR UPDATE NOWAIT` raises SQLSTATE 55P03
+    (classified via the unexported `sqlStateProvider` interface — works for
+    both `lib/pq.Error` and `pgx`-style errors without a direct driver dep).
+  - `ErrCASConflict` when the marshal-compare disagrees (or, defensively, when
+    a SQLite-mode UPDATE affects zero rows).
 
-**Note**: `FOR UPDATE NOWAIT` fails immediately if row is locked by another transaction.
+**Dialect split:**
+
+- **Postgres (production):** real CAS. `FOR UPDATE NOWAIT` blocks concurrent
+  writers between SELECT and UPDATE; contention surfaces as
+  `ErrLockNotAvailable`.
+- **SQLite (in-memory test only):** lock clause elided. The comparator
+  still catches stale-`from` callers, but two truly concurrent writers can
+  race past it with no conflict raised. Acceptable because SQLite usage is
+  single-process unit testing.
+
+Callers must not mutate `from`'s business state between load and call. The
+comparator is metadata-insensitive (both sides are compute-normalized), so
+embedded audit stamps need not match — only business fields do.
 
 #### Pessimistic Locking
 [lock.go:50-54](lock.go#L50-L54)

--- a/lib/db/README.md
+++ b/lib/db/README.md
@@ -181,9 +181,14 @@ objWithMd, err := objSet.Tenant(tenant).SelectByIDWithMetadata(ctx, id)
 // Update: Fails if object doesn't exist
 err := objSet.Tenant(tenant).Update(ctx, obj)
 
-// SafeUpdate: Optimistic concurrency control
-// Only updates if 'from' matches current state
+// SafeUpdate: Optimistic concurrency control.
+// Only updates if 'from' matches current state. On a stale 'from' returns
+// ErrCASConflict; on a row missing returns ErrObjectNotFound; on a contended
+// FOR UPDATE NOWAIT (Postgres only) returns ErrLockNotAvailable.
 err := objSet.Tenant(tenant).SafeUpdate(ctx, from, to)
+if errors.Is(err, db.ErrCASConflict) {
+    // 409 — caller's snapshot is stale; reload and retry.
+}
 ```
 
 ### Delete Operations
@@ -223,9 +228,35 @@ current, _ := objSet.Tenant(tenant).SelectByID(ctx, id)
 modified := *current
 modified.Field = "new value"
 
-// Only succeeds if current hasn't changed
+// Only succeeds if current hasn't changed since SelectByID.
 err := objSet.Tenant(tenant).SafeUpdate(ctx, *current, modified)
+switch {
+case errors.Is(err, db.ErrObjectNotFound):
+    // 404 — row deleted out from under us.
+case errors.Is(err, db.ErrLockNotAvailable):
+    // 409 — another writer holds the row (Postgres NOWAIT contention).
+case errors.Is(err, db.ErrCASConflict):
+    // 409 — row mutated between SelectByID and SafeUpdate; reload and retry.
+}
 ```
+
+**Error handling:**
+
+| Error                 | Cause                                                         | Typical HTTP |
+|-----------------------|---------------------------------------------------------------|--------------|
+| `ErrObjectNotFound`   | Row missing for the given ID                                  | 404          |
+| `ErrLockNotAvailable` | Another transaction holds `FOR UPDATE NOWAIT` on the row      | 409          |
+| `ErrCASConflict`      | Row mutated between caller's load and `SafeUpdate`            | 409          |
+
+`SafeUpdate` is a true CAS only on Postgres. On SQLite the row lock is elided;
+the comparator guards against stale-`from` callers but two truly concurrent
+writers can race past it. Use SQLite for tests, Postgres for production.
+
+The comparator normalizes both the current row and your `from` snapshot
+through the object set's compute hooks before comparing, so it compares
+business state and ignores embedded metadata (audit stamps). You may load
+`from` via any path (`SelectByID`, `Process`, hand-built) — just don't mutate
+its business fields between load and call.
 
 ### Pessimistic Locking
 

--- a/lib/db/database.go
+++ b/lib/db/database.go
@@ -57,8 +57,13 @@ func (conn connection) Open() (*sql.DB, error) {
 
 type config map[Vault]map[convAuth.Tenant]connections
 
+type engineDB struct {
+	db     *sql.DB
+	engine Engine
+}
+
 var (
-	dbs     map[Vault]map[convAuth.Tenant][]*sql.DB
+	dbs     map[Vault]map[convAuth.Tenant][]engineDB
 	dbsOnce sync.Once
 	dbsErr  error
 
@@ -77,7 +82,7 @@ func Open() (err error) {
 
 func openInternal() (err error) {
 
-	newDbs := make(map[Vault]map[convAuth.Tenant][]*sql.DB)
+	newDbs := make(map[Vault]map[convAuth.Tenant][]engineDB)
 
 	cfg, err := convCfg.Object[config](configKeyDatabase)
 	if err != nil {
@@ -85,14 +90,14 @@ func openInternal() (err error) {
 	}
 
 	for vault, vaultCfg := range cfg {
-		newDbs[vault] = make(map[convAuth.Tenant][]*sql.DB)
+		newDbs[vault] = make(map[convAuth.Tenant][]engineDB)
 		for tenant, tenantCfg := range vaultCfg {
 			for _, conn := range tenantCfg {
 				db, err := conn.Open()
 				if err != nil {
 					return err
 				}
-				newDbs[vault][tenant] = append(newDbs[vault][tenant], db)
+				newDbs[vault][tenant] = append(newDbs[vault][tenant], engineDB{db: db, engine: conn.Engine})
 			}
 		}
 	}
@@ -104,12 +109,12 @@ func openInternal() (err error) {
 }
 
 func Close() (err error) {
-	for _, db := range dbs {
-		for _, db := range db {
-			for _, db := range db {
+	for _, vault := range dbs {
+		for _, entries := range vault {
+			for _, entry := range entries {
 				err = errors.Join(
 					err,
-					db.Close(),
+					entry.db.Close(),
 				)
 			}
 		}
@@ -129,6 +134,20 @@ func indexByShardKey(key string, count int) int {
 }
 
 func DBs(vault Vault, tenant convAuth.Tenant) ([]*sql.DB, error) {
+
+	entries, err := engineDBs(vault, tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*sql.DB, len(entries))
+	for i, e := range entries {
+		out[i] = e.db
+	}
+	return out, nil
+}
+
+func engineDBs(vault Vault, tenant convAuth.Tenant) ([]engineDB, error) {
 
 	err := Open()
 	if err != nil {
@@ -182,6 +201,25 @@ func dbByShardKey(vault Vault, tenant convAuth.Tenant, key string) (*sql.DB, err
 	}
 
 	return dbs[0], nil
+}
+
+func dbByShardKeyWithEngine(vault Vault, tenant convAuth.Tenant, key string) (*sql.DB, Engine, error) {
+
+	entries, err := engineDBs(vault, tenant)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if len(entries) <= 0 {
+		return nil, "", ErrNoDBTenant
+	}
+
+	if len(entries) > 1 {
+		e := entries[indexByShardKey(key, len(entries))]
+		return e.db, e.engine, nil
+	}
+
+	return entries[0].db, entries[0].engine, nil
 }
 
 func dbsByShardKeys(vault Vault, tenant convAuth.Tenant, keys ...string) ([]*sql.DB, error) {

--- a/lib/db/main_test.go
+++ b/lib/db/main_test.go
@@ -1,6 +1,8 @@
 package db_test
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -50,6 +52,68 @@ var messagesDB = convDB.NewObjectSet[Message]("messages").
 		},
 	).
 	Ready()
+
+type ComplexID string
+
+type ComplexNested struct {
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
+type ComplexObject struct {
+	ComplexID ComplexID         `json:"complex_id"`
+	Title     string            `json:"title"`
+	Nested    ComplexNested     `json:"nested"`
+	Tags      []string          `json:"tags"`
+	Attrs     map[string]string `json:"attrs"`
+
+	// failOn is a test hook used by transaction_rollback_on_marshal_failure.
+	// When set, MarshalJSON increments the counter and returns an error once
+	// it reaches failOn. encoding/json skips unexported fields, so the hook
+	// has no effect on the serialised bytes.
+	marshalCount *int
+	failOn       int
+}
+
+var errMarshalInjected = errors.New("injected marshal failure")
+
+func (c ComplexObject) MarshalJSON() ([]byte, error) {
+	if c.marshalCount != nil {
+		*c.marshalCount++
+		if *c.marshalCount >= c.failOn {
+			return nil, errMarshalInjected
+		}
+	}
+	type alias ComplexObject
+	return json.Marshal(alias(c))
+}
+
+func (c ComplexObject) DBKey() convDB.Key[ComplexID, ComplexID] {
+	return convDB.Key[ComplexID, ComplexID]{
+		ID:       c.ComplexID,
+		ShardKey: c.ComplexID,
+	}
+}
+
+var complexDB = convDB.NewObjectSet[ComplexObject]("complex").Ready()
+
+type SplitID string
+type SplitShard string
+
+type SplitKeyObject struct {
+	SplitID    SplitID    `json:"split_id"`
+	SplitShard SplitShard `json:"split_shard"`
+	Payload    string     `json:"payload"`
+}
+
+func (s SplitKeyObject) DBKey() convDB.Key[SplitID, SplitShard] {
+	return convDB.Key[SplitID, SplitShard]{
+		ID:       s.SplitID,
+		ShardKey: s.SplitShard,
+	}
+}
+
+var splitKeyDB = convDB.NewObjectSet[SplitKeyObject]("complex").Ready()
 
 func TestMain(m *testing.M) {
 

--- a/lib/db/object.go
+++ b/lib/db/object.go
@@ -192,9 +192,9 @@ ON "` + runtimeTableName + `" USING gin ("text_search");
 `
 	}
 
-	for _, dbs := range tenantDBs {
-		for _, db := range dbs {
-			_, err = db.Exec(createScript)
+	for _, entries := range tenantDBs {
+		for _, entry := range entries {
+			_, err = entry.db.Exec(createScript)
 			if err != nil {
 				return
 			}

--- a/lib/db/update.go
+++ b/lib/db/update.go
@@ -9,6 +9,29 @@ import (
 	convCtx "github.com/sofmon/convention/lib/ctx"
 )
 
+var (
+	ErrObjectNotFound   = errors.New("convention/db: object not found")
+	ErrLockNotAvailable = errors.New("convention/db: row lock not available")
+	ErrCASConflict      = errors.New("convention/db: object modified since read")
+)
+
+// sqlStateProvider is implemented by both lib/pq.Error and pgx-style PgError,
+// letting us classify SQLSTATEs without a direct driver dependency.
+type sqlStateProvider interface {
+	SQLState() string
+}
+
+func classifyContentionErr(err error) (mapped error, ok bool) {
+	if err == nil {
+		return nil, false
+	}
+	var pgErr sqlStateProvider
+	if errors.As(err, &pgErr) && pgErr.SQLState() == "55P03" {
+		return ErrLockNotAvailable, true
+	}
+	return nil, false
+}
+
 func (tos TenantObjectSet[objT, idT, shardKeyT]) Update(ctx convCtx.Context, obj objT) (err error) {
 
 	err = tos.prepare()
@@ -80,6 +103,22 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) Update(ctx convCtx.Context, obj
 	return
 }
 
+// SafeUpdate is an optimistic-concurrency primitive: persist `to` only if the
+// current row still matches the caller's `from` snapshot. Returns
+// ErrObjectNotFound if the row is missing, ErrLockNotAvailable on contended
+// NOWAIT acquisition (Postgres only), and ErrCASConflict on a stale `from`.
+//
+// True CAS is Postgres-only — the `FOR UPDATE NOWAIT` row lock is required to
+// block concurrent writers between the SELECT and the UPDATE. SQLite mode
+// elides the lock; the comparator still catches stale-`from` callers but two
+// truly concurrent SQLite writers can race past it. Use SQLite for tests,
+// Postgres for production.
+//
+// Callers must not mutate `from`'s business state between load and call.
+// Both the current row and `from` are normalized through the same
+// decode→compute-hook→marshal pipeline before comparison, so the guard
+// compares business state and is insensitive to embedded metadata (and to
+// how `from` was loaded — SelectByID, Process, or hand-built).
 func (tos TenantObjectSet[objT, idT, shardKeyT]) SafeUpdate(ctx convCtx.Context, from, to objT) (err error) {
 
 	err = tos.prepare()
@@ -99,7 +138,7 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) SafeUpdate(ctx convCtx.Context,
 		return
 	}
 
-	db, err := dbByShardKey(tos.vault, tos.tenant, string(fromKey.ShardKey))
+	db, engine, err := dbByShardKeyWithEngine(tos.vault, tos.tenant, string(fromKey.ShardKey))
 	if err != nil {
 		return
 	}
@@ -119,36 +158,88 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) SafeUpdate(ctx convCtx.Context,
 		err = tx.Commit()
 	}()
 
+	var lockClause string
+	if engine == EnginePostgres {
+		lockClause = " FOR UPDATE NOWAIT"
+	}
+
 	var (
+		cmpData []byte
 		cmp     objT
-		cmpHash string
 		md      Metadata
 	)
-	row := tx.QueryRow(`SELECT "object", md5("object"), "created_at", "created_by", "updated_at", "updated_by"  FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1 FOR UPDATE NOWAIT`, fromKey.ID)
-	err = row.Scan(&cmp, &cmpHash, &md.CreatedAt, &md.CreatedBy, &md.UpdatedAt, &md.UpdatedBy)
+	row := tx.QueryRow(`SELECT "object", "created_at", "created_by", "updated_at", "updated_by" FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1`+lockClause, fromKey.ID)
+	err = row.Scan(&cmpData, &md.CreatedAt, &md.CreatedBy, &md.UpdatedAt, &md.UpdatedBy)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("object with ID '%s' does not exist", fromKey.ID)
+		err = fmt.Errorf("%w: id=%s", ErrObjectNotFound, fromKey.ID)
+		return
 	}
+	if err != nil {
+		if mapped, ok := classifyContentionErr(err); ok {
+			err = fmt.Errorf("%w: id=%s", mapped, fromKey.ID)
+		}
+		return
+	}
+
+	err = json.Unmarshal(cmpData, &cmp)
 	if err != nil {
 		return
 	}
 
-	md.UpdatedAt = ctx.Now()
-	md.UpdatedBy = ctx.User()
+	// Normalize both sides through the same pipeline before comparing:
+	// decode the row, then run the compute hooks with the just-loaded
+	// metadata, then marshal. `from` is cloned (marshal→unmarshal) and put
+	// through the identical hooks so the comparison is insensitive to how
+	// the caller loaded it. This matters because compute hooks typically
+	// copy the row metadata (created/updated stamps) onto the object, and
+	// that metadata legitimately differs by load path and timestamp
+	// precision: a `from` from SelectByID carries column-precision stamps,
+	// one from Process (which skips compute hooks) carries the raw stored
+	// JSON stamps, and on Postgres the JSONB object keeps nanoseconds while
+	// the columns are microseconds. Normalizing both sides with the same
+	// loaded md cancels that out, so the CAS guard compares business state
+	// only — matching the intent "did the row change since the caller read
+	// it" rather than "do the embedded metadata bytes match".
+	for _, compute := range tos.compute {
+		err = compute(ctx, md, &cmp)
+		if err != nil {
+			return
+		}
+	}
 
 	cmpBytes, err := json.Marshal(cmp)
 	if err != nil {
 		return
 	}
 
-	fromBytes, err := json.Marshal(from)
+	var fromCmp objT
+	fromRaw, err := json.Marshal(from)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(fromRaw, &fromCmp)
+	if err != nil {
+		return
+	}
+	for _, compute := range tos.compute {
+		err = compute(ctx, md, &fromCmp)
+		if err != nil {
+			return
+		}
+	}
+
+	fromBytes, err := json.Marshal(fromCmp)
 	if err != nil {
 		return
 	}
 
 	if string(cmpBytes) != string(fromBytes) {
-		return fmt.Errorf("object with ID '%s' has been modified since it was retrieved", fromKey.ID)
+		err = fmt.Errorf("%w: id=%s", ErrCASConflict, fromKey.ID)
+		return
 	}
+
+	md.UpdatedAt = ctx.Now()
+	md.UpdatedBy = ctx.User()
 
 	for _, compute := range tos.compute {
 		err = compute(ctx, md, &to)
@@ -162,8 +253,8 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) SafeUpdate(ctx convCtx.Context,
 		return
 	}
 
-	res, err := tx.Exec(`UPDATE "`+tos.table.RuntimeTableName+`" SET "object"=$1, "updated_at"=$2, "updated_by"=$3 WHERE "id"=$4 AND md5("object")=$5`,
-		toBytes, md.UpdatedAt, md.UpdatedBy, toKey.ID, cmpHash)
+	res, err := tx.Exec(`UPDATE "`+tos.table.RuntimeTableName+`" SET "object"=$1, "updated_at"=$2, "updated_by"=$3 WHERE "id"=$4`,
+		toBytes, md.UpdatedAt, md.UpdatedBy, toKey.ID)
 	if err != nil {
 		return
 	}
@@ -174,7 +265,8 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) SafeUpdate(ctx convCtx.Context,
 	}
 
 	if count == 0 {
-		return fmt.Errorf("object with ID '%s' has been modified since it was retrieved", fromKey.ID)
+		err = fmt.Errorf("%w: id=%s", ErrCASConflict, fromKey.ID)
+		return
 	}
 
 	_, err = tx.Exec(`INSERT INTO "`+tos.table.HistoryTableName+`" SELECT "id", "created_at", "created_by", "updated_at", "updated_by", "object" FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1`,

--- a/lib/db/update_internal_test.go
+++ b/lib/db/update_internal_test.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeSQLStateErr struct{ state string }
+
+func (e fakeSQLStateErr) Error() string    { return "fake: " + e.state }
+func (e fakeSQLStateErr) SQLState() string { return e.state }
+
+func Test_classifyContentionErr(t *testing.T) {
+	t.Run("55P03_maps_to_ErrLockNotAvailable", func(t *testing.T) {
+		mapped, ok := classifyContentionErr(fakeSQLStateErr{state: "55P03"})
+		if !ok {
+			t.Fatalf("expected ok=true for SQLSTATE 55P03")
+		}
+		if !errors.Is(mapped, ErrLockNotAvailable) {
+			t.Fatalf("expected ErrLockNotAvailable, got %v", mapped)
+		}
+	})
+
+	t.Run("other_sqlstate_does_not_map", func(t *testing.T) {
+		mapped, ok := classifyContentionErr(fakeSQLStateErr{state: "23505"})
+		if ok || mapped != nil {
+			t.Fatalf("expected (nil, false) for non-55P03 SQLSTATE, got (%v, %v)", mapped, ok)
+		}
+	})
+
+	t.Run("plain_error_does_not_map", func(t *testing.T) {
+		mapped, ok := classifyContentionErr(errors.New("plain"))
+		if ok || mapped != nil {
+			t.Fatalf("expected (nil, false) for plain error, got (%v, %v)", mapped, ok)
+		}
+	})
+
+	t.Run("nil_error_does_not_map", func(t *testing.T) {
+		mapped, ok := classifyContentionErr(nil)
+		if ok || mapped != nil {
+			t.Fatalf("expected (nil, false) for nil error, got (%v, %v)", mapped, ok)
+		}
+	})
+}

--- a/lib/db/update_test.go
+++ b/lib/db/update_test.go
@@ -1,10 +1,16 @@
 package db_test
 
 import (
+	"database/sql"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 
 	convAuth "github.com/sofmon/convention/lib/auth"
 	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
 )
 
 func Test_Update(t *testing.T) {
@@ -64,6 +70,416 @@ func Test_Update(t *testing.T) {
 	}
 }
 
-func Test_SageUpdate(t *testing.T) {
-	t.Skip("No md5 function in sqlite")
+// newComplexFixture inserts a fresh ComplexObject with random ID + payload and
+// returns the loaded copy so each sub-test starts from a clean slate.
+func newComplexFixture(t *testing.T, ctx convCtx.Context, suffix string) ComplexObject {
+	t.Helper()
+	obj := ComplexObject{
+		ComplexID: ComplexID(uuid.NewString()),
+		Title:     "title-" + suffix,
+		Nested:    ComplexNested{Label: "nested-" + suffix, Count: 7},
+		Tags:      []string{"a", "b", "c"},
+		Attrs:     map[string]string{"k1": "v1", "k2": "v2"},
+	}
+	if err := complexDB.Tenant("test").Insert(ctx, obj); err != nil {
+		t.Fatalf("Insert failed: %v", err)
+	}
+	got, err := complexDB.Tenant("test").SelectByID(ctx, obj.ComplexID)
+	if err != nil {
+		t.Fatalf("SelectByID failed: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("SelectByID returned nil")
+	}
+	return *got
+}
+
+func historyRowCount(t *testing.T, vault convDB.Vault, runtimeTable string, id string) int {
+	t.Helper()
+	dbs, err := convDB.DBs(vault, "test")
+	if err != nil {
+		t.Fatalf("DBs failed: %v", err)
+	}
+	total := 0
+	for _, db := range dbs {
+		var n int
+		err := db.QueryRow(`SELECT COUNT(*) FROM "`+runtimeTable+`_history" WHERE "id"=?`, id).Scan(&n)
+		if err != nil && err != sql.ErrNoRows {
+			t.Fatalf("history count failed: %v", err)
+		}
+		total += n
+	}
+	return total
+}
+
+func Test_SafeUpdate(t *testing.T) {
+
+	ctx := convCtx.New(convAuth.Claims{User: "Test_SafeUpdate"})
+
+	t.Run("happy_path", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "happy")
+		to := from
+		to.Title = "updated-happy"
+		to.Tags = []string{"x", "y"}
+		to.Attrs = map[string]string{"only": "value"}
+
+		if err := complexDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate failed: %v", err)
+		}
+
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Title != "updated-happy" {
+			t.Fatalf("expected updated-happy, got %+v", got)
+		}
+		if len(got.Tags) != 2 || got.Tags[0] != "x" {
+			t.Fatalf("tags not persisted: %v", got.Tags)
+		}
+		if got.Attrs["only"] != "value" {
+			t.Fatalf("attrs not persisted: %v", got.Attrs)
+		}
+	})
+
+	t.Run("regression_md5_jsonb", func(t *testing.T) {
+		// Pre-fix this row would have failed in two distinct ways: md5("object")
+		// against JSONB (Postgres) / no such function: md5 (SQLite), AND a
+		// Scan-into-objT mismatch in database/sql. The nested+slice+map payload
+		// here ensures we genuinely exercise the JSONB-shape codepath.
+		from := newComplexFixture(t, ctx, "md5")
+		to := from
+		to.Nested.Count = 99
+		to.Tags = append(append([]string{}, from.Tags...), "extra")
+		to.Attrs = map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}
+
+		if err := complexDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate failed: %v", err)
+		}
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Nested.Count != 99 || got.Attrs["k3"] != "v3" {
+			t.Fatalf("nested/map update not persisted: %+v", got)
+		}
+	})
+
+	t.Run("compute_hooks_normalise_cmp", func(t *testing.T) {
+		// Simulate the Postgres µs/ns timestamp divergence (stored JSONB keeps
+		// nanoseconds while the timestamp column truncates to microseconds) by
+		// manually rewriting the runtime row's "object" JSON after Insert so
+		// the embedded created_at / updated_at diverge from the metadata
+		// columns. SelectByID's compute hook recovers the column value onto
+		// `from`; SafeUpdate must do the same to `cmp`, otherwise the
+		// marshal-compare false-conflicts on every call.
+		msg := Message{MessageID: MessageID(uuid.NewString()), Content: "normalise"}
+		if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+			t.Fatalf("Insert failed: %v", err)
+		}
+
+		bogus := `{"message_id":"` + string(msg.MessageID) +
+			`","content":"normalise","created_at":"1900-01-01T00:00:00Z",` +
+			`"updated_at":"1900-01-01T00:00:00Z"}`
+		dbs, err := convDB.DBs("messages", "test")
+		if err != nil {
+			t.Fatalf("DBs failed: %v", err)
+		}
+		var affected int64
+		for _, db := range dbs {
+			res, execErr := db.Exec(`UPDATE "message" SET "object"=? WHERE "id"=?`, bogus, string(msg.MessageID))
+			if execErr != nil {
+				t.Fatalf("raw UPDATE failed: %v", execErr)
+			}
+			n, _ := res.RowsAffected()
+			affected += n
+		}
+		if affected != 1 {
+			t.Fatalf("expected exactly one shard to hold the row, got %d", affected)
+		}
+
+		loaded, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if loaded.CreatedAt.Year() == 1900 {
+			t.Fatalf("compute hook did not recover CreatedAt from metadata column; got %v", loaded.CreatedAt)
+		}
+
+		from := *loaded
+		to := from
+		to.Content = "post-normalise"
+		if err := messagesDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate should succeed via cmp normalisation; got %v", err)
+		}
+
+		after, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID after SafeUpdate failed: %v", err)
+		}
+		if after.Content != "post-normalise" {
+			t.Fatalf("update did not persist, got %+v", after)
+		}
+	})
+
+	t.Run("compute_hooks_run", func(t *testing.T) {
+		// messagesDB has a compute hook that copies metadata onto the object;
+		// running SafeUpdate against it lets us assert the hook still fires
+		// post-refactor.
+		msg := Message{MessageID: MessageID(uuid.NewString()), Content: "before"}
+		if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+			t.Fatalf("Insert failed: %v", err)
+		}
+		loaded, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		from := *loaded
+		to := from
+		to.Content = "after"
+
+		if err := messagesDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate failed: %v", err)
+		}
+		after, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID after SafeUpdate failed: %v", err)
+		}
+		if after.UpdatedAt.Equal(from.UpdatedAt) || after.UpdatedAt.Before(from.UpdatedAt) {
+			t.Fatalf("UpdatedAt did not advance: before=%v after=%v", from.UpdatedAt, after.UpdatedAt)
+		}
+		if !after.CreatedAt.Equal(from.CreatedAt) {
+			t.Fatalf("CreatedAt should be stable: before=%v after=%v", from.CreatedAt, after.CreatedAt)
+		}
+	})
+
+	t.Run("from_metadata_divergence_no_false_conflict", func(t *testing.T) {
+		// A caller that loaded `from` via a path that did NOT run compute
+		// hooks (e.g. Process, which selects only "object") hands SafeUpdate
+		// a `from` whose embedded metadata diverges from the row's
+		// compute-normalized metadata. Business state matches the row, so
+		// SafeUpdate must succeed — the comparator normalizes `from` through
+		// the same compute pipeline as the current row and compares business
+		// state only.
+		msg := Message{MessageID: MessageID(uuid.NewString()), Content: "orig"}
+		if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+			t.Fatalf("Insert failed: %v", err)
+		}
+		loaded, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+
+		// Correct business state, deliberately wrong embedded metadata.
+		bogus := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+		from := *loaded
+		from.CreatedAt = bogus
+		from.UpdatedAt = bogus
+
+		to := from
+		to.Content = "updated"
+
+		if err := messagesDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate should succeed despite divergent from metadata; got %v", err)
+		}
+		after, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID after SafeUpdate failed: %v", err)
+		}
+		if after.Content != "updated" {
+			t.Fatalf("update did not persist: %+v", after)
+		}
+		if after.CreatedAt.Year() == 1900 {
+			t.Fatalf("compute hook should have re-stamped CreatedAt, got %v", after.CreatedAt)
+		}
+	})
+
+	t.Run("from_metadata_divergence_preserves_business_conflict", func(t *testing.T) {
+		// Normalizing `from`'s metadata must NOT mask a genuine business-state
+		// conflict: a `from` with both divergent metadata AND stale business
+		// state still trips ErrCASConflict.
+		msg := Message{MessageID: MessageID(uuid.NewString()), Content: "orig"}
+		if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+			t.Fatalf("Insert failed: %v", err)
+		}
+		loaded, err := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+
+		bogus := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+		from := *loaded
+		from.CreatedAt = bogus
+		from.UpdatedAt = bogus
+		from.Content = "stale-different" // business state no longer matches the row
+
+		to := from
+		to.Content = "attempted-update"
+
+		err = messagesDB.Tenant("test").SafeUpdate(ctx, from, to)
+		if !errors.Is(err, convDB.ErrCASConflict) {
+			t.Fatalf("expected ErrCASConflict for stale business state, got %v", err)
+		}
+	})
+
+	t.Run("history_row_inserted", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "history")
+		preCount := historyRowCount(t, "complex", "complex_object", string(from.ComplexID))
+		to := from
+		to.Title = "history-updated"
+
+		if err := complexDB.Tenant("test").SafeUpdate(ctx, from, to); err != nil {
+			t.Fatalf("SafeUpdate failed: %v", err)
+		}
+		postCount := historyRowCount(t, "complex", "complex_object", string(from.ComplexID))
+		if postCount != preCount+1 {
+			t.Fatalf("expected one new history row, got pre=%d post=%d", preCount, postCount)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		ghost := ComplexObject{
+			ComplexID: ComplexID(uuid.NewString()),
+			Title:     "ghost",
+		}
+		err := complexDB.Tenant("test").SafeUpdate(ctx, ghost, ghost)
+		if !errors.Is(err, convDB.ErrObjectNotFound) {
+			t.Fatalf("expected ErrObjectNotFound, got %v", err)
+		}
+	})
+
+	t.Run("cas_conflict_via_update", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "cas-update")
+		racer := from
+		racer.Title = "raced-by-update"
+		if err := complexDB.Tenant("test").Update(ctx, racer); err != nil {
+			t.Fatalf("racer Update failed: %v", err)
+		}
+		to := from
+		to.Title = "loser"
+
+		err := complexDB.Tenant("test").SafeUpdate(ctx, from, to)
+		if !errors.Is(err, convDB.ErrCASConflict) {
+			t.Fatalf("expected ErrCASConflict, got %v", err)
+		}
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Title != "raced-by-update" {
+			t.Fatalf("racer write should have stuck, got %+v", got)
+		}
+	})
+
+	t.Run("cas_conflict_via_safeupdate", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "cas-safeupdate")
+		racerFrom := from
+		racerTo := from
+		racerTo.Title = "raced-by-safeupdate"
+		if err := complexDB.Tenant("test").SafeUpdate(ctx, racerFrom, racerTo); err != nil {
+			t.Fatalf("racer SafeUpdate failed: %v", err)
+		}
+		to := from
+		to.Title = "loser"
+
+		err := complexDB.Tenant("test").SafeUpdate(ctx, from, to)
+		if !errors.Is(err, convDB.ErrCASConflict) {
+			t.Fatalf("expected ErrCASConflict, got %v", err)
+		}
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Title != "raced-by-safeupdate" {
+			t.Fatalf("racer write should have stuck, got %+v", got)
+		}
+	})
+
+	t.Run("id_mismatch", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "id-mismatch")
+		to := from
+		to.ComplexID = ComplexID(uuid.NewString())
+		err := complexDB.Tenant("test").SafeUpdate(ctx, from, to)
+		if err == nil || err.Error() != "cannot safely update object with different IDs" {
+			t.Fatalf("expected ID-mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("shard_key_mismatch", func(t *testing.T) {
+		from := SplitKeyObject{
+			SplitID:    SplitID(uuid.NewString()),
+			SplitShard: SplitShard("shard-a"),
+			Payload:    "p",
+		}
+		to := from
+		to.SplitShard = SplitShard("shard-b")
+		err := splitKeyDB.Tenant("test").SafeUpdate(ctx, from, to)
+		if err == nil || err.Error() != "cannot safely update object with different shard keys" {
+			t.Fatalf("expected shard-key-mismatch error, got %v", err)
+		}
+	})
+
+	t.Run("stale_from_marshal_compare", func(t *testing.T) {
+		// Caller-side mutation of `from` between load and call must surface as
+		// ErrCASConflict — the comparator is intentionally strict.
+		from := newComplexFixture(t, ctx, "stale-from")
+		mutatedFrom := from
+		mutatedFrom.Title = "caller-bug"
+
+		to := from
+		to.Title = "intended-update"
+		err := complexDB.Tenant("test").SafeUpdate(ctx, mutatedFrom, to)
+		if !errors.Is(err, convDB.ErrCASConflict) {
+			t.Fatalf("expected ErrCASConflict for stale from, got %v", err)
+		}
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Title != from.Title {
+			t.Fatalf("row should be unchanged, got %+v", got)
+		}
+	})
+
+	t.Run("transaction_rollback_on_marshal_failure", func(t *testing.T) {
+		from := newComplexFixture(t, ctx, "rollback")
+		preCount := historyRowCount(t, "complex", "complex_object", string(from.ComplexID))
+
+		// Both sides of the comparator and the UPDATE call MarshalJSON on
+		// values whose counter and threshold we control. cmp is decoded
+		// inside lib/db with no counter, so it serialises without tripping
+		// the hook. The hook fires on the 3rd Marshal call (cmp marshal
+		// would be #1 on cmp's nil-counter copy, but only the from/to
+		// counter advances; so threshold 2 fires on the to-marshal).
+		counter := 0
+		fromMutated := from
+		fromMutated.marshalCount = &counter
+		fromMutated.failOn = 2
+
+		to := from
+		to.marshalCount = &counter
+		to.failOn = 2
+		to.Title = "should-not-persist"
+
+		err := complexDB.Tenant("test").SafeUpdate(ctx, fromMutated, to)
+		if !errors.Is(err, errMarshalInjected) {
+			t.Fatalf("expected injected marshal failure, got %v", err)
+		}
+
+		got, err := complexDB.Tenant("test").SelectByID(ctx, from.ComplexID)
+		if err != nil {
+			t.Fatalf("SelectByID failed: %v", err)
+		}
+		if got == nil || got.Title != from.Title {
+			t.Fatalf("row should be unchanged after rollback, got %+v", got)
+		}
+		postCount := historyRowCount(t, "complex", "complex_object", string(from.ComplexID))
+		if postCount != preCount {
+			t.Fatalf("history row should not have been inserted: pre=%d post=%d", preCount, postCount)
+		}
+	})
+
+	t.Run("lock_not_available_integration", func(t *testing.T) {
+		t.Skip("requires Postgres for FOR UPDATE NOWAIT; covered downstream by a real-Postgres integration test")
+	})
 }


### PR DESCRIPTION
## What changed

`SafeUpdate` no longer uses `md5(jsonb)` (unsupported by Postgres against JSONB columns), and no longer tries to `Scan` JSONB bytes directly into a Go struct (`database/sql` rejects that). The new path scans into `[]byte`, unmarshals into `objT`, then runs a decode-then-remarshal comparator — matching `SelectByID`'s pattern.

**Both sides of the comparator are now normalized through the same `decode → compute-hook → marshal` pipeline** (using the just-loaded row metadata) before the byte comparison: `cmp` (the current row) and a clone of the caller's `from`. Compute hooks typically copy the row's created/updated stamps onto the object, and that embedded metadata legitimately differs by load path and timestamp precision — a `from` from `SelectByID` carries column-precision stamps, one from `Process` (which skips compute hooks) carries the raw stored-JSON stamps, and on Postgres the JSONB object keeps nanoseconds while the columns are microseconds. Normalizing both sides with the same `md` cancels that out, so the CAS guard compares **business state only** — matching the intent "did the row change since the caller read it" rather than "do the embedded metadata bytes match". Callers may now load `from` via any path (`SelectByID`, `Process`, hand-built) without false-conflicting.

The `FOR UPDATE NOWAIT` clause is now dialect-aware (Postgres only); SQLite mode elides the lock, which lets convention's own SQLite CI exercise the non-contention `SafeUpdate` flow (happy path + stale-`from` CAS conflicts + every error/validation branch) end-to-end. **True contention CAS (concurrent writers blocked by the row lock) remains Postgres-only**; the `SafeUpdate` docstring and `AGENTS.md` make this explicit.

Three exported sentinel errors — `ErrObjectNotFound`, `ErrLockNotAvailable`, `ErrCASConflict` — replace the previous opaque `fmt.Errorf` returns, with `errors.Is`-friendly `%w` wrapping. SQLSTATE 55P03 (`lock_not_available`) from a contended NOWAIT is classified via a small driver-agnostic `sqlStateProvider` interface (`SQLState() string`, implemented by both `lib/pq.Error` and `pgx`-style errors), so no new driver dep is added.

To support dialect-aware locking, the internal DB registry tracks `Engine` alongside `*sql.DB`; the public `DBs(vault, tenant) ([]*sql.DB, error)` return type is unchanged. A new unexported `dbByShardKeyWithEngine` helper exposes engine-aware access internally.

Docs in `lib/db/README.md` and `lib/db/AGENTS.md` are updated accordingly (new Error Handling table, Postgres/SQLite dialect split documentation).

## Why

`SafeUpdate` has been unusable against any JSONB-backed ObjectSet — which is every ObjectSet whose `object` column is declared JSONB by convention itself (`lib/db/object.go:159, 174`). The previous `Test_SageUpdate` skipped under SQLite (`"No md5 function in sqlite"`), hiding the bug from CI; against real Postgres the call fails with SQLSTATE 42883 (`function md5(jsonb) does not exist`). Downstream services that needed CAS semantics have been forced into hand-rolled workarounds (which compared business state with the embedded metadata zeroed out — exactly the semantics the both-sides normalization now provides generically); this fix lets them retire those.

## How it was verified

Test suite split across two files:

- `lib/db/update_test.go` (`package db_test`) — `Test_SafeUpdate` table-driven parent with **14 SQLite-reachable sub-tests** (happy path, all three sentinel error paths, compute-hook order preservation, `cmp` + `from` metadata normalisation, history-row write, strict comparator contract, id/shard-key validation, mid-tx rollback on marshal failure). The `compute_hooks_normalise_cmp` and `from_metadata_divergence_*` sub-tests reproduce the Postgres µs/ns precision divergence on SQLite (by raw-rewriting the runtime row's `"object"` column, and by handing `SafeUpdate` a `from` with deliberately divergent embedded metadata) — locking in the both-sides normalisation without requiring real Postgres, and asserting it never masks a genuine business-state conflict.
- `lib/db/update_internal_test.go` (`package db`, new file) — `Test_classifyContentionErr` with 4 unit sub-tests covering the unexported SQLSTATE classifier against a synthetic `sqlStateProvider`, independent of any real driver.

One sub-test (`lock_not_available_integration`) skips on SQLite with a documented Postgres-only reason; that contention path is exercised by a downstream real-Postgres integration test.

Verification scoped to `go test ./lib/db/...` — green. Full `./...` needs additional reviewer-local secrets for unrelated packages (`lib/api` TLS setup, `lib/job` vault config). `go vet ./lib/db/...`, `gofmt -l lib/db/`, and `go mod tidy` (no introduced direct deps) are clean.

## Notes for reviewer

Three design decisions baked into the PR, each open for pushback:

1. **Metadata-insensitive comparator (both-sides normalization).** The CAS guard compares business state, not embedded metadata. The trade-off is that it drops ABA-via-metadata detection — a write that only advances the timestamps without changing business state no longer trips the guard. This matches how the hand-rolled downstream workarounds already behaved (they zeroed the audit stamps before comparing). If you'd rather keep metadata in the comparison (preserving ABA detection), the alternative is to require callers to always load `from` through a compute-running path (`SelectByID`/`Select`) and only normalize `cmp` — happy to switch if you prefer that contract.
2. **SQLSTATE classification via `sqlStateProvider` interface.** Driver-agnostic — works for `lib/pq.Error` and `pgx`-style errors via their shared `SQLState() string` method. Alternative: typed `*pq.Error` assertion, which would add `github.com/lib/pq` as a new direct dep — explicitly avoided.
3. **SQLite-mode lock elision.** On SQLite, `FOR UPDATE NOWAIT` is dropped from the SELECT (SQLite doesn't parse it). `ErrLockNotAvailable` is therefore Postgres-only behaviour. Documented in the `SafeUpdate` docstring and `AGENTS.md`.

**Behaviour-change note:** error message format changes (now wraps sentinels via `%w`); any downstream that previously string-matched the old `fmt.Errorf` wording will break. Migrate to `errors.Is(err, ErrXxx)`. The previous `SafeUpdate` was unusable against JSONB ObjectSets so this is unlikely to bite anyone in practice, but it's a backward-incompatible diff worth calling out.