### PR TITLE
fix(job,db): heartbeat-lease job lock + idempotent Register

### DIFF
--- a/lib/db/AGENTS.md
+++ b/lib/db/AGENTS.md
@@ -318,31 +318,49 @@ Callers must not mutate `from`'s business state between load and call. The
 comparator is metadata-insensitive (both sides are compute-normalized), so
 embedded audit stamps need not match — only business fields do.
 
-#### Pessimistic Locking
-[lock.go:50-54](lock.go#L50-L54)
+#### Pessimistic Locking — two modes
 
+`Lock(ctx, obj, desc, opts ...LockOption)` has two modes selected by `WithLease`.
+
+**Default mode (sticky mutex — unchanged):**
 ```go
 res, err := db.Exec(`INSERT INTO "`+tos.table.LockTableName+`"
     ("id","created_at","description")
     VALUES($1,$2,$3)
     ON CONFLICT ("id") DO NOTHING;`, key.ID, ctx.Now(), desc)
 ```
+- `ON CONFLICT DO NOTHING`; `RowsAffected()==0` → returns `nil` (already locked); never stolen.
+- Lock persists until `lock.Unlock()` (unconditional `DELETE WHERE id`).
+- This is what request-scoped callers rely on (e.g. a resend cooldown, a "someone is already processing" guard). **Do not change it.**
 
-- Uses `ON CONFLICT DO NOTHING` to make lock acquisition atomic
-- Checks `RowsAffected()` to determine if lock was acquired
-- Returns `nil` lock if already locked
-- Lock persists until explicitly unlocked via `lock.Unlock()`
+**Lease mode (`WithLease(d)` — for long-lived / scheduled holders):**
+```go
+res, err := db.ExecContext(ctx.Context, `INSERT INTO "`+lockTable+`" AS l
+    ("id","created_at","description") VALUES($1,$2,$3)
+    ON CONFLICT ("id") DO UPDATE SET "created_at"=$2, "description"=$3
+    WHERE l."created_at" < $4;`, key.ID, now, desc, now.Add(-d))
+```
+- A lock whose `created_at` is older than `now-lease` is **stolen** (so a holder that crashed without unlocking does not block forever). `RowsAffected()==1` ⇒ acquired or stole; `==0` ⇒ a live (recently-renewed) lock is held.
+- `created_at` doubles as the heartbeat timestamp. The holder must `Renew(ctx)` well within `lease` (advances `created_at WHERE id AND description=owner`; returns `ErrLeaseLost` on 0 rows).
+- `Unlock()` is **owner-safe** for lease locks (`DELETE WHERE id AND description=owner`, bounded context); returns `ErrLeaseLost` if the lock was stolen away.
+- The stored `description` is the caller's text plus a **per-acquisition token** (`desc + "\x1f" + uuid`), so `Renew`/`Unlock` match one specific acquisition — two holders that pass the same `desc` are never confused. `PreviousOwner()` strips the token back to the caller text.
+- `UpdateGuarded(ctx, obj)` persists the locked object **only while this caller still owns the lease**, with no read-then-write window. In one transaction it first renews the lease row with an owner-checked `UPDATE lock SET created_at=now WHERE id AND description=owner` — 0 rows ⇒ `ErrLeaseLost`; otherwise it holds that row's write lock, so a concurrent steal (the `ON CONFLICT DO UPDATE`) blocks until commit. It renews the lease **once more right before commit**, so even a long transaction leaves a timestamp newer than any blocked waiter's cutoff (the waiter called `Lock` before this commit) — that waiter cannot take over. The runtime write + ownership claim are thus mutually exclusive with stealing. Not context-cancellable, so it still lands and decides ownership during shutdown.
+- `Stolen()` / `PreviousOwner()` expose advisory acquisition metadata (set when an expired row was replaced) for logging.
+- The explicit target alias `AS l` keeps the predicate bound to the existing row (never `excluded.created_at`) and is accepted by both Postgres and SQLite. The cutoff is computed in Go and bound as a parameter (no SQL interval arithmetic) for cross-engine parity. Steal comparison assumes NTP-synced clocks.
 
 **Lock struct**:
 ```go
 type Lock[objT, idT, shardKeyT] struct {
-    tos TenantObjectSet[objT, idT, shardKeyT]
-    si  int  // Shard index
-    id  idT
+    tos   TenantObjectSet[objT, idT, shardKeyT]
+    si    int           // Shard index
+    id    idT
+    owner string        // "" => legacy lock; else desc + per-acquisition token
+    stolen        bool   // advisory: replaced an expired row
+    previousOwner string // advisory: description of the replaced row
 }
 ```
 
-Stores shard index to unlock on correct database instance.
+Stores shard index to unlock on the correct database instance; `owner` makes Renew/Unlock owner-safe in lease mode.
 
 ### Multi-Shard Operations
 

--- a/lib/db/lock.go
+++ b/lib/db/lock.go
@@ -1,17 +1,81 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
 
 	convCtx "github.com/sofmon/convention/lib/ctx"
 )
+
+// unlockTimeout bounds the owner-safe DELETE in a lease lock's Unlock so a stalled
+// DB cannot hang a job's teardown indefinitely. The legacy (non-lease) path is
+// unchanged and uses Exec without a deadline.
+const unlockTimeout = 5 * time.Second
+
+// ownerTokenSep separates the caller's human-readable lock description from a unique
+// per-acquisition token in the stored "description". Ownership (Renew/Unlock) matches the
+// whole stored value, so two acquisitions that pass the same description are still distinct
+// owners. It is a control byte that does not occur in a human description, so PreviousOwner
+// can strip the token back off for logging.
+const ownerTokenSep = "\x1f"
+
+// LockOption configures a Lock acquisition.
+type LockOption func(*lockConfig)
+
+type lockConfig struct {
+	lease time.Duration
+}
+
+// WithLease enables heartbeat-lease semantics on a Lock acquisition:
+//
+//   - An existing lock whose created_at is older than lease is treated as expired
+//     and stolen, so an owner that crashed without unlocking no longer blocks
+//     forever.
+//   - The returned Lock is owner-safe: Renew and Unlock only affect a row this
+//     caller still owns (matched by description), so they never disturb a lock that
+//     was stolen away after expiry.
+//
+// The holder is expected to Renew well within lease (see lib/job's scheduler).
+// Without this option Lock behaves as a sticky mutex (INSERT ... ON CONFLICT DO
+// NOTHING) that is never stolen — the long-standing default existing callers rely on.
+func WithLease(d time.Duration) LockOption {
+	return func(c *lockConfig) { c.lease = d }
+}
 
 type Lock[objT Object[idT, shardKeyT], idT, shardKeyT ~string] struct {
 	tos TenantObjectSet[objT, idT, shardKeyT]
 	si  int
 	id  idT
+
+	// owner is the description this caller wrote. "" marks a legacy (non-lease)
+	// lock whose Unlock deletes unconditionally by id.
+	owner string
+
+	// stolen / previousOwner are advisory acquisition metadata (logging only),
+	// set when the lease acquire replaced an existing (expired) row.
+	stolen        bool
+	previousOwner string
+}
+
+// Stolen reports whether this lease lock was acquired by replacing an existing
+// expired lock (i.e. the previous holder likely crashed without unlocking).
+func (l Lock[objT, idT, shardKeyT]) Stolen() bool { return l.stolen }
+
+// PreviousOwner returns the human-readable description of the expired lock this
+// acquisition replaced (the per-acquisition token is stripped), or "" if none. Advisory
+// (best-effort), for logging.
+func (l Lock[objT, idT, shardKeyT]) PreviousOwner() string {
+	if i := strings.Index(l.previousOwner, ownerTokenSep); i >= 0 {
+		return l.previousOwner[:i]
+	}
+	return l.previousOwner
 }
 
 func (l Lock[objT, idT, shardKeyT]) Unlock() (err error) {
@@ -21,7 +85,167 @@ func (l Lock[objT, idT, shardKeyT]) Unlock() (err error) {
 		return
 	}
 
-	_, err = db.Exec(`DELETE FROM "`+l.tos.table.LockTableName+`"WHERE "id"=$1;`, l.id)
+	if l.owner == "" {
+		// Legacy lock: unconditional delete by id (unchanged behaviour).
+		_, err = db.Exec(`DELETE FROM "`+l.tos.table.LockTableName+`" WHERE "id"=$1;`, l.id)
+		return
+	}
+
+	// Lease lock: owner-safe delete on a bounded context so teardown/shutdown can
+	// still release the lock. Never removes a row a different owner has stolen.
+	dctx, cancel := context.WithTimeout(context.Background(), unlockTimeout)
+	defer cancel()
+
+	res, err := db.ExecContext(dctx,
+		`DELETE FROM "`+l.tos.table.LockTableName+`" WHERE "id"=$1 AND "description"=$2;`,
+		l.id, l.owner)
+	if err != nil {
+		return
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrLeaseLost
+	}
+	return
+}
+
+// Renew refreshes a lease lock's timestamp (heartbeat). It returns ErrLeaseLost
+// when the row is no longer owned by this holder (expired and stolen, or cleared),
+// so the caller can stop work and let the new owner take over. Uses ExecContext so
+// a cancelled context interrupts an in-flight renew.
+func (l Lock[objT, idT, shardKeyT]) Renew(ctx convCtx.Context) (err error) {
+
+	if l.owner == "" {
+		return fmt.Errorf("convention/db: Renew called on a non-lease lock")
+	}
+
+	db, err := dbByIndex(l.tos.vault, l.tos.tenant, l.si)
+	if err != nil {
+		return
+	}
+
+	res, err := db.ExecContext(ctx.Context,
+		`UPDATE "`+l.tos.table.LockTableName+`" SET "created_at"=$1 WHERE "id"=$2 AND "description"=$3;`,
+		ctx.Now(), l.id, l.owner)
+	if err != nil {
+		return
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrLeaseLost
+	}
+	return
+}
+
+// UpdateGuarded persists obj exactly like Update, but only while this caller still owns the
+// lease — and it does so without any read-then-write window. Inside one transaction it first
+// renews the lease row with an owner-checked UPDATE, which (a) returns ErrLeaseLost if the
+// row no longer names this owner and (b) takes the lease row's write lock for the rest of the
+// transaction. A concurrent steal (the ON CONFLICT DO UPDATE in Lock) must lock the same row,
+// so it blocks until this transaction commits. The lease is renewed once more immediately
+// before commit, so even if the transaction ran longer than the lease a blocked waiter sees a
+// timestamp newer than its cutoff (it called Lock before our commit) and cannot steal. The
+// object write and the ownership claim are therefore mutually exclusive with stealing, so a
+// holder whose lease was taken over cannot persist a stale write. Lease locks only (acquired
+// WithLease); obj must be the locked object.
+//
+// Not context-cancellable (it uses db.Begin/tx.Exec like Update), intentionally: the guarded
+// write must still land — and decide ownership — even when the caller's context is already
+// cancelled (e.g. during scheduler shutdown).
+func (l Lock[objT, idT, shardKeyT]) UpdateGuarded(ctx convCtx.Context, obj objT) (err error) {
+
+	if l.owner == "" {
+		return fmt.Errorf("convention/db: UpdateGuarded requires a lease lock (use WithLease)")
+	}
+
+	tos := l.tos
+	if err = tos.prepare(); err != nil {
+		return
+	}
+
+	key := obj.DBKey()
+	if key.ID != l.id {
+		return fmt.Errorf("convention/db: UpdateGuarded object id %q does not match locked id %q", key.ID, l.id)
+	}
+
+	db, err := dbByShardKey(tos.vault, tos.tenant, string(key.ShardKey))
+	if err != nil {
+		return
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, tx.Rollback())
+			return
+		}
+		err = tx.Commit()
+	}()
+
+	// Take the lease row first: this owner-checked renew refreshes the heartbeat AND holds
+	// the lease row's write lock for the rest of the transaction, so a concurrent steal blocks
+	// until commit (then sees a fresh timestamp and cannot take over). 0 rows ⇒ the lease was
+	// already stolen/cleared ⇒ ErrLeaseLost, before any runtime write.
+	leaseRes, err := tx.Exec(`UPDATE "`+tos.table.LockTableName+`" SET "created_at"=$1 WHERE "id"=$2 AND "description"=$3`,
+		ctx.Now(), l.id, l.owner)
+	if err != nil {
+		return
+	}
+	if n, _ := leaseRes.RowsAffected(); n == 0 {
+		err = ErrLeaseLost
+		return
+	}
+
+	var md Metadata
+	err = tx.QueryRow(`SELECT "created_at", "created_by", "updated_at", "updated_by" FROM "`+tos.table.RuntimeTableName+`" WHERE id=$1`, key.ID).
+		Scan(&md.CreatedAt, &md.CreatedBy, &md.UpdatedAt, &md.UpdatedBy)
+	if err == sql.ErrNoRows {
+		err = fmt.Errorf("object with ID '%s' does not exist", key.ID)
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	md.UpdatedAt = ctx.Now()
+	md.UpdatedBy = ctx.User()
+
+	for _, compute := range tos.compute {
+		err = compute(ctx, md, &obj)
+		if err != nil {
+			return
+		}
+	}
+
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return
+	}
+
+	// Ownership is already guaranteed (and held under the lease row lock) by the renew above,
+	// so this is a plain owned write.
+	_, err = tx.Exec(`UPDATE "`+tos.table.RuntimeTableName+`" SET "object"=$1, "updated_at"=$2, "updated_by"=$3 WHERE "id"=$4`,
+		bytes, md.UpdatedAt, md.UpdatedBy, key.ID)
+	if err != nil {
+		return
+	}
+
+	_, err = tx.Exec(`INSERT INTO "`+tos.table.HistoryTableName+`" SELECT "id", "created_at", "created_by", "updated_at", "updated_by", "object" FROM "`+tos.table.RuntimeTableName+`" WHERE "id"=$1`,
+		key.ID)
+	if err != nil {
+		return
+	}
+
+	// Refresh the lease one last time before commit. The early renew's timestamp could be
+	// older than `lease` by now if this transaction ran long; a waiter that called Lock after
+	// that early renew computed its cutoff against the wall clock and would, the moment we
+	// release the row lock at commit, see a stale created_at and steal — then run the job we
+	// just advanced. Renewing here makes the timestamp this waiter observes (it called Lock
+	// before our commit, so before this `now`) newer than its cutoff, so it cannot steal. We
+	// still hold the row lock, so this matches our own row (1 row).
+	_, err = tx.Exec(`UPDATE "`+tos.table.LockTableName+`" SET "created_at"=$1 WHERE "id"=$2 AND "description"=$3`,
+		ctx.Now(), l.id, l.owner)
 	if err != nil {
 		return
 	}
@@ -29,11 +253,16 @@ func (l Lock[objT, idT, shardKeyT]) Unlock() (err error) {
 	return
 }
 
-func (tos TenantObjectSet[objT, idT, shardKeyT]) Lock(ctx convCtx.Context, obj objT, desc string) (lock *Lock[objT, idT, shardKeyT], err error) {
+func (tos TenantObjectSet[objT, idT, shardKeyT]) Lock(ctx convCtx.Context, obj objT, desc string, opts ...LockOption) (lock *Lock[objT, idT, shardKeyT], err error) {
 
 	err = tos.prepare()
 	if err != nil {
 		return
+	}
+
+	var cfg lockConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	key := obj.DBKey()
@@ -47,28 +276,95 @@ func (tos TenantObjectSet[objT, idT, shardKeyT]) Lock(ctx convCtx.Context, obj o
 
 	db := dbs[si]
 
-	res, err := db.Exec(`INSERT INTO "`+tos.table.LockTableName+`"
+	if cfg.lease <= 0 {
+		// Legacy sticky-lock path — unchanged behaviour (never steals).
+		var res sql.Result
+		res, err = db.Exec(`INSERT INTO "`+tos.table.LockTableName+`"
 ("id","created_at","description")
 VALUES($1,$2,$3)
 ON CONFLICT ("id") DO NOTHING;`,
-		key.ID, ctx.Now(), desc)
+			key.ID, ctx.Now(), desc)
+		if err != nil {
+			return
+		}
+
+		var count int64
+		count, err = res.RowsAffected()
+		if err != nil {
+			return
+		}
+
+		if count == 0 {
+			return // someone was faster, no lock
+		}
+
+		lock = &Lock[objT, idT, shardKeyT]{
+			tos: tos,
+			si:  si,
+			id:  key.ID,
+		}
+
+		return
+	}
+
+	// Lease path: steal an expired lock and tag it with this owner.
+	now := ctx.Now()
+	cutoff := now.Add(-cfg.lease)
+
+	// Per-acquisition owner tag: the caller's desc plus a unique token. Renew/Unlock match
+	// the whole stored value, so two acquisitions sharing a description can never be mistaken
+	// for the same owner (a stale holder cannot renew/unlock a row a new holder took over).
+	ownerTag := desc + ownerTokenSep + uuid.NewString()
+
+	// Advisory pre-read (best-effort, logging only) of the prior holder, so the
+	// caller can report a steal. Correctness rests solely on the atomic upsert below.
+	var prior string
+	priorExists := false
+	switch scanErr := db.QueryRowContext(ctx.Context,
+		`SELECT "description" FROM "`+tos.table.LockTableName+`" WHERE "id"=$1`, key.ID).
+		Scan(&prior); scanErr {
+	case nil:
+		priorExists = true
+	case sql.ErrNoRows:
+		priorExists = false
+	default:
+		err = scanErr
+		return
+	}
+
+	// Explicit target alias "l" so the WHERE references the EXISTING row, never
+	// excluded.created_at. Accepted by both Postgres and SQLite. RowsAffected==1
+	// means inserted-or-stole; ==0 means a live (recently-renewed) lock is held.
+	var res sql.Result
+	res, err = db.ExecContext(ctx.Context,
+		`INSERT INTO "`+tos.table.LockTableName+`" AS l ("id","created_at","description")
+VALUES($1,$2,$3)
+ON CONFLICT ("id") DO UPDATE SET "created_at"=$2, "description"=$3
+WHERE l."created_at" < $4;`,
+		key.ID, now, ownerTag, cutoff)
 	if err != nil {
 		return
 	}
 
-	count, err := res.RowsAffected()
+	var count int64
+	count, err = res.RowsAffected()
 	if err != nil {
 		return
 	}
 
 	if count == 0 {
-		return // someone was faster, no lock
+		return // live lock held by another owner
 	}
 
 	lock = &Lock[objT, idT, shardKeyT]{
-		tos: tos,
-		si:  si,
-		id:  key.ID,
+		tos:   tos,
+		si:    si,
+		id:    key.ID,
+		owner: ownerTag,
+	}
+	if priorExists {
+		lock.stolen = true
+		lock.previousOwner = prior
 	}
 
 	return

--- a/lib/db/lock_lease_test.go
+++ b/lib/db/lock_lease_test.go
@@ -1,0 +1,274 @@
+package db_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	convAuth "github.com/sofmon/convention/lib/auth"
+	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
+)
+
+const testLease = 60 * time.Second
+
+// leaseCtx returns a context whose Now() is pinned, so lease arithmetic is fully
+// deterministic (no sleeps).
+func leaseCtx(user string, now time.Time) convCtx.Context {
+	return convCtx.New(convAuth.Claims{User: convAuth.User(user)}).WithNow(now)
+}
+
+func leaseMsg() Message {
+	return Message{MessageID: MessageID("lease-" + uuid.NewString())}
+}
+
+// A stale lease lock is stolen on acquire, and the steal is reported.
+func Test_Lock_StealAfterExpiry(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	msg := leaseMsg()
+
+	lockA, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerA", base), msg, "ownerA", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("ownerA acquire: lock=%v err=%v", lockA, err)
+	}
+	if lockA.Stolen() {
+		t.Fatalf("a fresh acquire must not be marked stolen")
+	}
+
+	// Before expiry, a second owner cannot steal.
+	early, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease/2)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil {
+		t.Fatalf("ownerB early acquire err: %v", err)
+	}
+	if early != nil {
+		t.Fatalf("ownerB must not steal a live lock")
+	}
+
+	// After expiry, the second owner steals and learns the previous owner.
+	lockB, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease+time.Second)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil || lockB == nil {
+		t.Fatalf("ownerB steal: lock=%v err=%v", lockB, err)
+	}
+	if !lockB.Stolen() {
+		t.Fatalf("expected Stolen()=true after taking over an expired lock")
+	}
+	if lockB.PreviousOwner() != "ownerA" {
+		t.Fatalf("PreviousOwner=%q, want ownerA", lockB.PreviousOwner())
+	}
+
+	if err := lockB.Unlock(); err != nil {
+		t.Fatalf("ownerB unlock: %v", err)
+	}
+}
+
+// Renewing keeps the lease alive so a would-be thief sees it as live (RowsAffected==0).
+func Test_Lock_RenewPreventsSteal(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	msg := leaseMsg()
+
+	lockA, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerA", base), msg, "ownerA", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("ownerA acquire: lock=%v err=%v", lockA, err)
+	}
+
+	// Heartbeat at base+lease/2 moves created_at forward.
+	if err := lockA.Renew(leaseCtx("ownerA", base.Add(testLease/2))); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+
+	// At base+lease the cutoff is base; the renewed created_at (base+lease/2) is
+	// newer, so the thief must fail.
+	thief, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil {
+		t.Fatalf("thief acquire err: %v", err)
+	}
+	if thief != nil {
+		t.Fatalf("renew should have kept the lease alive; thief must not steal")
+	}
+
+	if err := lockA.Unlock(); err != nil {
+		t.Fatalf("ownerA unlock: %v", err)
+	}
+}
+
+// A stale owner's Unlock returns ErrLeaseLost and must not remove the new owner's row.
+func Test_Lock_OwnerSafeUnlock(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	msg := leaseMsg()
+
+	lockA, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerA", base), msg, "ownerA", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("ownerA acquire: lock=%v err=%v", lockA, err)
+	}
+
+	lockB, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease+time.Second)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil || lockB == nil {
+		t.Fatalf("ownerB steal: lock=%v err=%v", lockB, err)
+	}
+
+	// ownerA lost the lease — its Unlock reports it and leaves ownerB's row intact.
+	if err := lockA.Unlock(); !errors.Is(err, convDB.ErrLeaseLost) {
+		t.Fatalf("stale owner Unlock: got %v, want ErrLeaseLost", err)
+	}
+
+	// Probe: ownerB's lock is still live (a fresh thief just past the steal time fails).
+	probe, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerC", base.Add(testLease+2*time.Second)), msg, "ownerC", convDB.WithLease(testLease))
+	if err != nil {
+		t.Fatalf("probe err: %v", err)
+	}
+	if probe != nil {
+		t.Fatalf("ownerA.Unlock must not have removed ownerB's live lock")
+	}
+
+	if err := lockB.Unlock(); err != nil {
+		t.Fatalf("ownerB unlock: %v", err)
+	}
+}
+
+// Ownership is per-acquisition, not per-description: two acquisitions that pass the SAME
+// human-readable description must still be distinct owners, so a stale holder cannot renew
+// or unlock a lock a new holder took over with the identical description.
+func Test_Lock_SameDescriptionDistinctOwners(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	msg := leaseMsg()
+
+	lockA, err := messagesDB.Tenant("test").Lock(leaseCtx("dup", base), msg, "dup", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("first acquire: lock=%v err=%v", lockA, err)
+	}
+
+	// A second caller takes over after expiry using the SAME description.
+	lockB, err := messagesDB.Tenant("test").Lock(leaseCtx("dup", base.Add(testLease+time.Second)), msg, "dup", convDB.WithLease(testLease))
+	if err != nil || lockB == nil {
+		t.Fatalf("second acquire (steal): lock=%v err=%v", lockB, err)
+	}
+
+	// The stale first holder must NOT be able to renew or unlock lockB's row despite the
+	// identical description — otherwise it would silently keep/steal a lock it no longer owns.
+	if err := lockA.Renew(leaseCtx("dup", base.Add(testLease+2*time.Second))); !errors.Is(err, convDB.ErrLeaseLost) {
+		t.Fatalf("stale holder Renew with identical description must report ErrLeaseLost, got %v", err)
+	}
+	if err := lockA.Unlock(); !errors.Is(err, convDB.ErrLeaseLost) {
+		t.Fatalf("stale holder Unlock with identical description must report ErrLeaseLost, got %v", err)
+	}
+
+	// lockB still genuinely owns it.
+	if err := lockB.Renew(leaseCtx("dup", base.Add(testLease+3*time.Second))); err != nil {
+		t.Fatalf("current holder Renew should succeed: %v", err)
+	}
+	if err := lockB.Unlock(); err != nil {
+		t.Fatalf("current holder Unlock: %v", err)
+	}
+}
+
+// UpdateGuarded persists only while the caller still holds a live lease: the write and the
+// ownership check are one atomic statement, so a stolen holder cannot persist a stale write.
+func Test_Lock_UpdateGuarded(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ctx := leaseCtx("owner", base)
+	msg := leaseMsg()
+	msg.Content = "v0"
+	if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	defer func() { _ = messagesDB.Tenant("test").Delete(leaseCtx("owner", base), msg.MessageID) }()
+
+	lockA, err := messagesDB.Tenant("test").Lock(ctx, msg, "ownerA", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("acquire: lock=%v err=%v", lockA, err)
+	}
+
+	// A live owner persists.
+	upd := msg
+	upd.Content = "v1"
+	if err := lockA.UpdateGuarded(leaseCtx("ownerA", base.Add(time.Second)), upd); err != nil {
+		t.Fatalf("live owner UpdateGuarded should succeed: %v", err)
+	}
+	if got, _ := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID); got == nil || got.Content != "v1" {
+		t.Fatalf("UpdateGuarded did not persist: %+v", got)
+	}
+
+	// The UpdateGuarded above renewed the lease (created_at = base+1s), so the steal must be
+	// at least one lease past that. A thief takes over; the stale owner's guarded write must
+	// NOT land.
+	lockB, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease+2*time.Second)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil || lockB == nil {
+		t.Fatalf("steal: lock=%v err=%v", lockB, err)
+	}
+	stale := msg
+	stale.Content = "v2-must-not-persist"
+	if err := lockA.UpdateGuarded(leaseCtx("ownerA", base.Add(testLease+3*time.Second)), stale); !errors.Is(err, convDB.ErrLeaseLost) {
+		t.Fatalf("stale owner UpdateGuarded must report ErrLeaseLost, got %v", err)
+	}
+	if got, _ := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID); got == nil || got.Content != "v1" {
+		t.Fatalf("stale UpdateGuarded must not have persisted: %+v", got)
+	}
+
+	// The current owner can still persist.
+	win := msg
+	win.Content = "v3"
+	if err := lockB.UpdateGuarded(leaseCtx("ownerB", base.Add(testLease+4*time.Second)), win); err != nil {
+		t.Fatalf("current owner UpdateGuarded: %v", err)
+	}
+	if err := lockB.Unlock(); err != nil {
+		t.Fatalf("ownerB unlock: %v", err)
+	}
+}
+
+// Expiry alone does not block UpdateGuarded: a holder whose lease lapsed but was NOT stolen
+// is still the sole owner, so its owner-checked renew succeeds and it persists. (Only an
+// actual steal blocks it — see Test_Lock_UpdateGuarded.) This avoids wasting a completed run
+// when the holder merely paused, e.g. a GC stall, without anyone taking over.
+func Test_Lock_UpdateGuardedExpiredButUnstolen(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ctx := leaseCtx("owner", base)
+	msg := leaseMsg()
+	msg.Content = "v0"
+	if err := messagesDB.Tenant("test").Insert(ctx, msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	defer func() { _ = messagesDB.Tenant("test").Delete(ctx, msg.MessageID) }()
+
+	lock, err := messagesDB.Tenant("test").Lock(ctx, msg, "owner", convDB.WithLease(testLease))
+	if err != nil || lock == nil {
+		t.Fatalf("acquire: lock=%v err=%v", lock, err)
+	}
+
+	// No renew and well past the lease, but nobody stole it — the owner-checked renew still
+	// matches this owner, so the write lands.
+	upd := msg
+	upd.Content = "v1"
+	if err := lock.UpdateGuarded(leaseCtx("owner", base.Add(testLease+time.Second)), upd); err != nil {
+		t.Fatalf("expired-but-unstolen lease should still persist (no steal happened): %v", err)
+	}
+	if got, _ := messagesDB.Tenant("test").SelectByID(ctx, msg.MessageID); got == nil || got.Content != "v1" {
+		t.Fatalf("expired-but-unstolen UpdateGuarded should have persisted: %+v", got)
+	}
+}
+
+// After a steal, the original owner's Renew reports ErrLeaseLost (the trigger the
+// scheduler uses to stop advancing the schedule).
+func Test_Lock_RenewAfterStealReturnsErrLeaseLost(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	msg := leaseMsg()
+
+	lockA, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerA", base), msg, "ownerA", convDB.WithLease(testLease))
+	if err != nil || lockA == nil {
+		t.Fatalf("ownerA acquire: lock=%v err=%v", lockA, err)
+	}
+
+	lockB, err := messagesDB.Tenant("test").Lock(leaseCtx("ownerB", base.Add(testLease+time.Second)), msg, "ownerB", convDB.WithLease(testLease))
+	if err != nil || lockB == nil {
+		t.Fatalf("ownerB steal: lock=%v err=%v", lockB, err)
+	}
+
+	if err := lockA.Renew(leaseCtx("ownerA", base.Add(testLease+2*time.Second))); !errors.Is(err, convDB.ErrLeaseLost) {
+		t.Fatalf("stale Renew: got %v, want ErrLeaseLost", err)
+	}
+
+	if err := lockB.Unlock(); err != nil {
+		t.Fatalf("ownerB unlock: %v", err)
+	}
+}

--- a/lib/db/update.go
+++ b/lib/db/update.go
@@ -13,6 +13,9 @@ var (
 	ErrObjectNotFound   = errors.New("convention/db: object not found")
 	ErrLockNotAvailable = errors.New("convention/db: row lock not available")
 	ErrCASConflict      = errors.New("convention/db: object modified since read")
+	// ErrLeaseLost is returned by a lease lock's Renew/Unlock when the row is no
+	// longer owned by this holder (it expired and was stolen, or was force-cleared).
+	ErrLeaseLost = errors.New("convention/db: lock lease lost")
 )
 
 // sqlStateProvider is implemented by both lib/pq.Error and pgx-style PgError,

--- a/lib/job/AGENTS.md
+++ b/lib/job/AGENTS.md
@@ -53,6 +53,16 @@ var (
 
 All package state is global. The package is designed as a singleton scheduler -- only one `Initialise` call is allowed at a time.
 
+In addition, the package holds lease tuning and the per-process owner token:
+
+```go
+var (
+    jobLease         = 90 * time.Second   // a lock not renewed within this is stealable
+    jobRenewInterval = 30 * time.Second   // heartbeat cadence (≈ lease/3)
+)
+var ownerToken string                     // per-process UUID, set in Initialise
+```
+
 ## Public API
 
 ### Initialise (job.go:133-149)
@@ -64,9 +74,10 @@ func Initialise(ctx convCtx.Context, vault convDB.Vault) error
 1. Acquires mutex
 2. Fails if already running (`cancel != nil`)
 3. Creates `jobsDB` via `convDB.NewObjectSet`
-4. Creates `wakeUp` channel (buffered, capacity 1)
-5. Creates cancellable context from provided context
-6. Launches `background()` goroutine
+4. Generates `ownerToken` (a per-process UUID used to tag lock ownership for the heartbeat lease)
+5. Creates `wakeUp` channel (buffered, capacity 1)
+6. Creates cancellable context from provided context
+7. Launches `background()` goroutine
 
 ### Register (job.go:42-91)
 
@@ -75,12 +86,12 @@ func Register(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, startAt ti
 ```
 
 1. Fails if `jobsDB == nil` (not initialised)
-2. Fails if job ID already exists in memory for tenant
-3. Checks database for existing job (`SelectByID`)
-4. If not in DB: creates new job and inserts
-5. If in DB: attaches the function and updates schedule parameters
-6. Stores in in-memory map
-7. Sends a non-blocking signal on `wakeUp` channel to wake the background loop
+2. **Idempotent re-registration**: if the job ID already exists in memory — including a nil-closure entry that `syncJobsFromDB` injected before this `Register` ran — it re-attaches the closure and refreshes the interval instead of returning "already exists". Callers therefore never need an Unregister+retry workaround for the sync race.
+3. Reads any persisted job (`SelectByID`). When a DB row exists and the interval is **unchanged**, its persisted `NextRunAt` is kept (a redeploy does not reset every job's clock). When the **interval changed**, `NextRunAt` is **re-anchored to `startAt`** so a shortened interval takes effect on deploy; `RepeatEvery` is persisted. `startAt` is otherwise only used for brand-new jobs.
+4. If not in DB: creates a new job and inserts
+5. **Persist-before-memory:** an interval change is written to the DB **first**; only on success is the in-memory map mutated. The scheduler goroutine is already running, so an un-persisted memory change that the next `syncJobsFromDB` reverts would flap. On `Update` error, memory is left untouched and the error returns.
+6. **Anchor-change escape hatch:** a *same-interval* fire-time change (daily 03:00→04:00, weekly Monday→Tuesday — same `RepeatEvery`) is **not** auto-re-anchored (to preserve no-clock-reset on redeploy). To change a fire time, do a deliberate one-time `Unregister` + `Register` (or use a new job ID). **Do not** reintroduce a per-deploy unregister/register dance for this.
+7. Sends a non-blocking signal on `wakeUp` (via `wake()`) to wake the background loop
 
 ### Unregister (job.go:93-116)
 
@@ -172,14 +183,18 @@ func executeJob(ctx convCtx.Context, tenant convAuth.Tenant, j job)
 Execution flow:
 
 1. **Guard**: Skip if `RepeatEvery <= 0` (prevents infinite loop in schedule advancement)
-2. **Lock**: `jobsDB.Tenant(tenant).Lock(ctx, j, ...)` -- non-blocking. If `lock == nil`, another instance holds it; skip silently.
-3. **Defer unlock**: `lock.Unlock()` is deferred immediately after acquisition
-4. **Execute**: Run `j.f(ctx)` inside a nested func with `recover()` for panic safety. Errors and panics are logged.
-5. **Advance schedule**: Compute `nextRunAt = NextRunAt + RepeatEvery`, advancing past any missed intervals via a `for` loop
-6. **Update memory**: Acquire mutex, update `NextRunAt` in the in-memory map
-7. **Update database**: Call `jobsDB.Tenant(tenant).Update(ctx, updatedJob)` to persist the new schedule
+2. **Acquire (heartbeat lease)**: `jobsDB.Tenant(tenant).Lock(ctx, j, "executing job <id> @ <ownerToken>", convDB.WithLease(jobLease))`. If `lock == nil`, a live lock is held by another instance — skip, but **log at Info** (no longer silent, so a genuinely stuck job is visible). If `lock.Stolen()`, log a Warn with `lock.PreviousOwner()` (the prior holder crashed without unlocking).
+3. **Cancellable job context**: copy the `convCtx.Context` and replace its embedded `context.Context` with a cancellable child (`jobCtx`). `j.f` receives `jobCtx` so a job that honours cancellation aborts on lease loss.
+4. **Heartbeat goroutine**: every `jobRenewInterval`, call `lock.Renew(jobCtx)`. On `ErrLeaseLost` (classified by `renewOutcome`) set `leaseLost` and `jobCancel()`; on a **transient** error, log and keep retrying (do NOT drop a live lease for a DB blip).
+5. **Teardown defer**: `jobCancel()` then `<-hbDone` (join — leak-free because `Renew` uses `ExecContext`, so the cancel interrupts an in-flight renew), then owner-safe `lock.Unlock()` (an `ErrLeaseLost` here is a Warn, meaning the lock was stolen mid-run).
+6. **Execute**: Run `j.f(jobCtx)` inside a nested func with `recover()`.
+7. **Gate on lease ownership**: if `leaseLost`, **return without advancing/persisting `NextRunAt`** — the new owner is now responsible for scheduling.
+8. **Advance schedule** (only when the lease was held throughout): `nextRunAt = NextRunAt + RepeatEvery`, advancing past missed intervals; update the in-memory map (under mutex) and persist via `Update`.
+9. **Completion log** (`"job execution completed"`, with `tenant`/`job_id`/`duration_ms`): emitted **only on genuine success** — `j.f` returned nil, did not panic, the lease was held, and the `Update` succeeded. A failed/panicked/lease-lost/update-failed run does **not** emit it. This is the uniform signal for "job ran"; alerting keys off its *absence* per (service, tenant, job).
 
-**Error policy**: `NextRunAt` is advanced even when the job function returns an error. This prevents a permanently failing job from retrying in a tight loop. The error is logged for observability.
+**Error policy**: `NextRunAt` is advanced even when the job function returns an error (a permanently failing job must not retry in a tight loop) — but NOT when the lease was lost mid-run. Note the advance is independent of *success*: the `"job execution completed"` log (not the schedule advance) is the success signal.
+
+**Heartbeat lease (why)**: the lock is acquired with a TTL lease and renewed while the job runs, so a holder that crashes without unlocking is reclaimable (its lock is stolen once stale) instead of orphaning the job forever. `jobLease`/`jobRenewInterval` are package vars (default 90s / 30s = 3 heartbeats per lease window). `jobLease` need not exceed job runtime — the heartbeat keeps long jobs (e.g. minutes-long reconciliations) alive; it only bounds how long a crashed holder blocks others. The steal comparison assumes pod clocks are NTP-synced within a few seconds. `ownerToken` is a per-process UUID set in `Initialise`; it tags the lock's `description` so Renew/Unlock are owner-safe.
 
 ## Database Interaction
 
@@ -199,24 +214,27 @@ The `convDB.NewObjectSet[job, JobID, JobID](vault).Ready()` call creates three t
 | `SelectByID` | `Register` | Check if job already exists in DB |
 | `Insert` | `Register` | Persist new job |
 | `Delete` | `Unregister` | Remove job from DB |
-| `Lock` | `executeJob` | Acquire execution lock |
-| `Unlock` | `executeJob` | Release execution lock |
+| `Lock` (`WithLease`) | `executeJob` | Acquire execution lock with a heartbeat lease |
+| `Renew` | `executeJob` heartbeat | Refresh the lease while the job runs |
+| `Unlock` | `executeJob` | Release execution lock (owner-safe) |
 | `Update` | `executeJob` | Persist updated `NextRunAt` |
 
 ### Lock Mechanism
 
-Uses `convDB` pessimistic locking ([lock.go](../db/lock.go)):
+The scheduler uses `convDB`'s **heartbeat-lease** lock mode ([lock.go](../db/lock.go)) via `Lock(..., convDB.WithLease(jobLease))`:
 
 ```sql
-INSERT INTO "job_lock" ("id","created_at","description")
+INSERT INTO "job_lock" AS l ("id","created_at","description")
 VALUES($1,$2,$3)
-ON CONFLICT ("id") DO NOTHING;
+ON CONFLICT ("id") DO UPDATE SET "created_at"=$2, "description"=$3
+WHERE l."created_at" < $4;     -- $4 = now - lease  (a stale lock is stolen)
 ```
 
 - Non-blocking: returns immediately
-- `RowsAffected == 1` means lock acquired
-- `RowsAffected == 0` means another instance holds the lock
-- Lock persists until `DELETE FROM "job_lock" WHERE "id"=$1`
+- `RowsAffected == 1` means the lock was acquired, or a stale one was stolen
+- `RowsAffected == 0` means a live (recently-renewed) lock is held by another instance
+- `created_at` doubles as the heartbeat timestamp; `Renew` advances it; `Unlock` is owner-safe (`WHERE "id"=$1 AND "description"=$2`) and never removes a lock stolen away after expiry
+- The plain `ON CONFLICT DO NOTHING` mode (no `WithLease`) is unchanged and still used by non-job callers that want a sticky, never-stolen mutex
 
 ## Concurrency Model
 
@@ -240,7 +258,7 @@ Database locks (not the in-memory mutex) provide cross-instance mutual exclusion
 1. **Tenant discovery is local**: Only tenants with at least one locally registered job are synced from the database.
 2. **Sequential job execution**: Due jobs within a single loop iteration are executed sequentially, not in parallel.
 3. **Mutex held during DB sync**: `syncJobsFromDB` holds the mutex while calling `SelectAll`, which blocks `Register`/`Unregister` during sync. For small job counts this is acceptable.
-4. **No job execution timeout**: Job functions can run indefinitely. The context has cancellation but no deadline per job.
+4. **No job execution timeout**: Job functions can run indefinitely. They now receive a context that is cancelled on lease loss, but there is still no per-job deadline; a job that ignores cancellation keeps running. Its scheduling is still gated (a lost-lease run does not advance `NextRunAt`), so the worst case is at-most-once extra side effects, not a corrupted schedule.
 5. **`JobState` type is unused**: Defined but not referenced anywhere.
 
 ## Common Modification Scenarios

--- a/lib/job/README.md
+++ b/lib/job/README.md
@@ -71,7 +71,7 @@ The scheduler runs a single background goroutine that repeats the following cycl
 
 1. **Sync** -- Every minute, fetch all jobs from the database for each known tenant and merge into the in-memory map. This picks up schedule changes made by other instances (e.g. updated `NextRunAt` after execution).
 
-2. **Execute** -- For each job where `NextRunAt <= now` and the job function is available locally, attempt to acquire a database lock. If the lock is acquired, execute the job; if not, skip it (another instance is handling it).
+2. **Execute** -- For each job where `NextRunAt <= now` and the job function is available locally, attempt to acquire a database lock with a **heartbeat lease**. If acquired, execute the job (renewing the lease in the background while it runs); if a live lock is held by another instance, skip it (logged, not silent).
 
 3. **Sleep** -- Compute the time until the next job is due or the next sync interval (whichever is sooner) and sleep until then.
 
@@ -80,11 +80,17 @@ The scheduler runs a single background goroutine that repeats the following cycl
 When a job is due:
 
 1. Instance A and Instance B both detect `NextRunAt <= now`
-2. Both attempt `INSERT INTO lock_table ... ON CONFLICT DO NOTHING`
-3. Only one succeeds (`RowsAffected == 1`) -- that instance executes the job
-4. The other gets `RowsAffected == 0` and silently skips
-5. After execution, the winning instance updates `NextRunAt` in the database and releases the lock
+2. Both attempt a lease acquire (`INSERT ... ON CONFLICT DO UPDATE ... WHERE created_at < now-lease`)
+3. Only one succeeds (`RowsAffected == 1`) -- that instance executes the job and renews the lease (heartbeat) while it runs
+4. The other gets `RowsAffected == 0` (a live lease is held) and skips (logged)
+5. After execution, the winning instance updates `NextRunAt` and releases the lock (owner-safe delete)
 6. On the next sync cycle, all instances pick up the updated schedule
+
+**Crash recovery:** because the lock carries a renewed lease, an instance that crashes mid-job (without unlocking) does not orphan the job forever — once the lease goes stale, another instance steals the lock on its next attempt. If the lease is lost mid-run (stolen/expired), that run does **not** advance `NextRunAt`; the new owner becomes responsible for scheduling.
+
+**Idempotent registration:** registering a job ID that already exists re-attaches the function and refreshes the schedule (it does not error), so a sync-vs-register race needs no caller-side workaround. Changing the **interval** re-anchors `NextRunAt` so a shortened interval takes effect on deploy (persisted before the in-memory update); a same-interval **fire-time** change (e.g. 03:00→04:00) is not auto-applied — use a deliberate `Unregister`+`Register`.
+
+**Completion signal:** a successful run emits `"job execution completed"` (`tenant`, `job_id`, `duration_ms`). A failed, panicked, lease-lost, or persist-failed run does not — so monitoring can alert on the *absence* of this log per (service, tenant, job).
 
 ### Job Functions
 

--- a/lib/job/export_test.go
+++ b/lib/job/export_test.go
@@ -1,0 +1,113 @@
+package job
+
+import (
+	"fmt"
+	"time"
+
+	convAuth "github.com/sofmon/convention/lib/auth"
+	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
+)
+
+// Test seams (compiled only into the package's test binary).
+
+// RenewOutcomeForTest exposes the heartbeat error classifier.
+func RenewOutcomeForTest(err error) bool { return renewOutcome(err) }
+
+// SetLeaseForTest shortens the lease/renew interval for tests and returns a
+// restore func.
+func SetLeaseForTest(lease, renew time.Duration) (restore func()) {
+	ol, or := jobLease, jobRenewInterval
+	jobLease, jobRenewInterval = lease, renew
+	return func() { jobLease, jobRenewInterval = ol, or }
+}
+
+// InjectNilClosureJobForTest mimics syncJobsFromDB pulling a DB row into the
+// in-memory map with a nil closure before Register runs.
+func InjectNilClosureJobForTest(tenant convAuth.Tenant, jid JobID, nextRunAt time.Time, repeat time.Duration) {
+	mut.Lock()
+	defer mut.Unlock()
+	if jobs == nil {
+		jobs = make(map[convAuth.Tenant]map[JobID]job)
+	}
+	if jobs[tenant] == nil {
+		jobs[tenant] = make(map[JobID]job)
+	}
+	jobs[tenant][jid] = job{ID: jid, NextRunAt: nextRunAt, RepeatEvery: repeat} // f == nil
+}
+
+// MemJobClosureForTest reports whether an in-memory entry exists and whether it
+// carries an executable closure.
+func MemJobClosureForTest(tenant convAuth.Tenant, jid JobID) (present, hasClosure bool) {
+	mut.Lock()
+	defer mut.Unlock()
+	j, ok := jobs[tenant][jid]
+	if !ok {
+		return false, false
+	}
+	return true, j.f != nil
+}
+
+// InsertJobRowForTest writes a job DB row directly.
+func InsertJobRowForTest(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, nextRunAt time.Time, repeat time.Duration) error {
+	return jobsDB.Tenant(tenant).Insert(ctx, job{ID: jid, NextRunAt: nextRunAt, RepeatEvery: repeat})
+}
+
+// ReadJobRowNextRunForTest reads the persisted next_run_at for a job.
+func ReadJobRowNextRunForTest(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID) (time.Time, bool, error) {
+	sj, err := jobsDB.Tenant(tenant).SelectByID(ctx, jid)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if sj == nil {
+		return time.Time{}, false, nil
+	}
+	return sj.NextRunAt, true, nil
+}
+
+// ReadJobRowForTest reads the persisted schedule (next_run_at + repeat_every) for a job.
+func ReadJobRowForTest(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID) (nextRunAt time.Time, repeatEvery time.Duration, ok bool, err error) {
+	sj, err := jobsDB.Tenant(tenant).SelectByID(ctx, jid)
+	if err != nil {
+		return time.Time{}, 0, false, err
+	}
+	if sj == nil {
+		return time.Time{}, 0, false, nil
+	}
+	return sj.NextRunAt, sj.RepeatEvery, true, nil
+}
+
+// StealJobLockForTest forcibly takes the execution lock for jid as a foreign
+// owner. A far-future Now() makes the steal succeed regardless of the current
+// holder's heartbeat, simulating a competing instance taking over.
+func StealJobLockForTest(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, lease time.Duration) error {
+	future := ctx.WithNow(time.Now().Add(24 * time.Hour))
+	lock, err := jobsDB.Tenant(tenant).Lock(future, job{ID: jid}, "thief @ test", convDB.WithLease(lease))
+	if err != nil {
+		return err
+	}
+	if lock == nil {
+		return fmt.Errorf("steal failed: lock unexpectedly still held")
+	}
+	return nil
+}
+
+// RunJobForTest invokes executeJob with a constructed job.
+func RunJobForTest(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, nextRunAt time.Time, repeat time.Duration, fn JobFunc) {
+	executeJob(ctx, tenant, job{ID: jid, NextRunAt: nextRunAt, RepeatEvery: repeat, f: fn})
+}
+
+// PinSingleConnForTest forces the vault's in-memory sqlite DBs to a single
+// connection so concurrent goroutines (the heartbeat + a foreign steal) share one
+// in-memory database. Postgres needs no such pinning. Call after the DBs are open
+// (e.g. after a first job-row write).
+func PinSingleConnForTest(vault convDB.Vault, tenant convAuth.Tenant) error {
+	dbs, err := convDB.DBs(vault, tenant)
+	if err != nil {
+		return err
+	}
+	for _, db := range dbs {
+		db.SetMaxOpenConns(1)
+	}
+	return nil
+}

--- a/lib/job/job.go
+++ b/lib/job/job.go
@@ -2,9 +2,13 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 
 	convAuth "github.com/sofmon/convention/lib/auth"
 	convCtx "github.com/sofmon/convention/lib/ctx"
@@ -40,6 +44,35 @@ var (
 	wakeUp chan struct{}
 )
 
+// Lease tuning for the per-execution job lock. jobRenewInterval must stay well
+// below jobLease so a couple of transient renew failures don't expire a live lease;
+// jobLease bounds how long a crashed holder's lock blocks others before it is
+// stolen (it need NOT exceed job runtime — the heartbeat keeps long jobs alive).
+// Package vars (not consts) so tests can shorten them. The steal comparison assumes
+// pod clocks are NTP-synced within a few seconds.
+var (
+	jobLease         = 90 * time.Second
+	jobRenewInterval = 30 * time.Second
+)
+
+// ownerToken uniquely identifies this process as a lock holder; set in Initialise.
+var ownerToken string
+
+// renewOutcome classifies a heartbeat Renew result: fatal==true means the lease is
+// confirmed lost (stop the job and let the new owner run); otherwise the heartbeat
+// retries on the next tick.
+func renewOutcome(err error) (fatal bool) {
+	return errors.Is(err, convDB.ErrLeaseLost)
+}
+
+// wake nudges the background loop to re-evaluate jobs (non-blocking).
+func wake() {
+	select {
+	case wakeUp <- struct{}{}:
+	default:
+	}
+}
+
 func Register(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, startAt time.Time, repeatEvery time.Duration, fn JobFunc) (err error) {
 
 	if jobsDB == nil {
@@ -58,41 +91,80 @@ func Register(ctx convCtx.Context, tenant convAuth.Tenant, jid JobID, startAt ti
 		jobs[tenant] = make(map[JobID]job)
 	}
 
-	if _, ok := jobs[tenant][jid]; ok {
-		err = fmt.Errorf("job with id %s already exists", jid)
-		return
-	}
-
 	savedJob, err := jobsDB.Tenant(tenant).SelectByID(ctx, jid)
 	if err != nil {
 		return
 	}
 
+	// Idempotent re-registration. The in-memory entry may carry a nil closure that
+	// syncJobsFromDB injected (it pulled the DB row in before this Register ran);
+	// re-attach the closure and refresh the interval instead of erroring, so
+	// callers don't need an Unregister+retry workaround.
+	if existing, ok := jobs[tenant][jid]; ok {
+		intervalChanged := savedJob != nil && savedJob.RepeatEvery != repeatEvery
+
+		// Decide the schedule: re-anchor to startAt when the interval changed (so a
+		// shortened interval takes effect on deploy); otherwise honour the persisted
+		// NextRunAt so a same-interval redeploy doesn't reset the clock. A same-interval
+		// *anchor* change (e.g. 03:00->04:00) is intentionally NOT re-anchored — it
+		// requires a deliberate Unregister+Register (see lib/job AGENTS.md).
+		nextRunAt := startAt
+		if savedJob != nil && !savedJob.NextRunAt.IsZero() && !intervalChanged {
+			nextRunAt = savedJob.NextRunAt
+		}
+
+		// Persist a schedule change BEFORE mutating memory: the scheduler goroutine is
+		// already running, so an un-persisted memory change that the next syncJobsFromDB
+		// reverts would flap. On Update error, leave memory untouched and return.
+		if intervalChanged {
+			updated := *savedJob
+			updated.RepeatEvery = repeatEvery
+			updated.NextRunAt = nextRunAt
+			if err = jobsDB.Tenant(tenant).Update(ctx, updated); err != nil {
+				return
+			}
+		}
+
+		// Memory mutation (closure re-attach is memory-only and always safe — it re-arms
+		// a sync-injected nil closure, the load-bearing idempotent behaviour).
+		existing.f = fn
+		existing.RepeatEvery = repeatEvery
+		existing.NextRunAt = nextRunAt
+		jobs[tenant][jid] = existing
+
+		wake()
+		return
+	}
+
 	if savedJob == nil {
-		savedJob = &job{
+		nj := job{
 			ID:          jid,
 			NextRunAt:   startAt,
 			RepeatEvery: repeatEvery,
 			f:           fn,
 		}
-
-		err = jobsDB.Tenant(tenant).Insert(ctx, *savedJob)
-		if err != nil {
+		if err = jobsDB.Tenant(tenant).Insert(ctx, nj); err != nil {
 			return
 		}
-	} else {
-		savedJob.f = fn
-		savedJob.NextRunAt = startAt
-		savedJob.RepeatEvery = repeatEvery
+		jobs[tenant][jid] = nj
+		wake()
+		return
 	}
 
-	jobs[tenant][jid] = *savedJob
-
-	// Wake up the background loop to evaluate the new job
-	select {
-	case wakeUp <- struct{}{}:
-	default:
+	// DB row exists but no in-memory entry yet (first Register after restart): keep the
+	// persisted NextRunAt as the schedule, attach the closure, and on an interval change
+	// re-anchor NextRunAt + persist (before the in-memory map assignment below).
+	nj := *savedJob
+	nj.f = fn
+	if savedJob.RepeatEvery != repeatEvery {
+		nj.RepeatEvery = repeatEvery
+		nj.NextRunAt = startAt // re-anchor on interval change
+		if err = jobsDB.Tenant(tenant).Update(ctx, nj); err != nil {
+			return // memory untouched: jobs[tenant][jid] not yet set
+		}
 	}
+	jobs[tenant][jid] = nj
+	wake()
 
 	return
 }
@@ -147,6 +219,8 @@ func Initialise(ctx convCtx.Context, vault convDB.Vault) (err error) {
 	}
 
 	jobsDB = convDB.NewObjectSet[job, JobID, JobID](vault).Ready()
+
+	ownerToken = uuid.NewString()
 
 	wakeUp = make(chan struct{}, 1)
 
@@ -305,8 +379,10 @@ func executeJob(ctx convCtx.Context, tenant convAuth.Tenant, j job) {
 		return
 	}
 
-	// Attempt to acquire DB lock (non-blocking)
-	lock, err := jobsDB.Tenant(tenant).Lock(ctx, j, fmt.Sprintf("executing job %s", j.ID))
+	// Acquire the per-execution lock with a heartbeat lease so a crashed holder's
+	// lock is reclaimable (stolen once stale) instead of orphaning the job forever.
+	desc := fmt.Sprintf("executing job %s @ %s", j.ID, ownerToken)
+	lock, err := jobsDB.Tenant(tenant).Lock(ctx, j, desc, convDB.WithLease(jobLease))
 	if err != nil {
 		ctx.Logger().Error("failed to acquire lock for job",
 			"tenant", string(tenant),
@@ -316,12 +392,81 @@ func executeJob(ctx convCtx.Context, tenant convAuth.Tenant, j job) {
 		return
 	}
 	if lock == nil {
-		// Another instance holds the lock
+		// A live lock is held by another instance — skip this tick. Logged (not
+		// silent) so a genuinely stuck job is visible in logs/alerts.
+		ctx.Logger().Info("job skipped: live lock held by another instance",
+			"tenant", string(tenant),
+			"job_id", string(j.ID),
+		)
 		return
 	}
+	if lock.Stolen() {
+		ctx.Logger().Warn("job lock stolen from an expired holder (previous owner likely crashed)",
+			"tenant", string(tenant),
+			"job_id", string(j.ID),
+			"previous_owner", lock.PreviousOwner(),
+		)
+	}
 
+	// Cancellable context for the job body + heartbeat. convCtx.Context embeds
+	// context.Context, so copying the struct and replacing the embedded context
+	// preserves all values while adding cancellation.
+	jobCtx := ctx
+	var jobCancel context.CancelFunc
+	jobCtx.Context, jobCancel = context.WithCancel(ctx.Context)
+
+	var leaseLost atomic.Bool
+	hbDone := make(chan struct{})
+
+	go func() {
+		defer close(hbDone)
+		ticker := time.NewTicker(jobRenewInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-jobCtx.Done():
+				return
+			case <-ticker.C:
+				rerr := lock.Renew(jobCtx)
+				if rerr == nil {
+					continue
+				}
+				if renewOutcome(rerr) {
+					// Confirmed lease loss: stop the job; the new owner takes over.
+					leaseLost.Store(true)
+					ctx.Logger().Error("job lost its lease mid-execution (stolen or expired)",
+						"tenant", string(tenant),
+						"job_id", string(j.ID),
+					)
+					jobCancel()
+					return
+				}
+				if jobCtx.Err() == nil {
+					// Transient error (e.g. DB blip): keep the heartbeat alive and
+					// retry next tick; a real loss surfaces later as ErrLeaseLost.
+					ctx.Logger().Warn("job lease renew failed (transient), will retry",
+						"tenant", string(tenant),
+						"job_id", string(j.ID),
+						"error", rerr.Error(),
+					)
+				}
+			}
+		}
+	}()
+
+	// Teardown: stop the heartbeat, join it (leak-free — Renew uses ExecContext so
+	// the cancel interrupts any in-flight renew), then owner-safe unlock.
 	defer func() {
-		if unlockErr := lock.Unlock(); unlockErr != nil {
+		jobCancel()
+		<-hbDone
+		switch unlockErr := lock.Unlock(); {
+		case unlockErr == nil:
+		case errors.Is(unlockErr, convDB.ErrLeaseLost):
+			ctx.Logger().Warn("job lease already lost at unlock (stolen mid-run)",
+				"tenant", string(tenant),
+				"job_id", string(j.ID),
+			)
+		default:
 			ctx.Logger().Error("failed to unlock job",
 				"tenant", string(tenant),
 				"job_id", string(j.ID),
@@ -330,10 +475,16 @@ func executeJob(ctx convCtx.Context, tenant convAuth.Tenant, j job) {
 		}
 	}()
 
-	// Execute job function with panic recovery
+	// Execute job function with panic recovery. j.f receives jobCtx so a job that
+	// honours context cancellation aborts promptly on lease loss. Capture the outcome so
+	// the completion log fires only on genuine success (not on mere schedule advance).
+	var jobErr error
+	var jobPanicked bool
+	startedAt := time.Now()
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
+				jobPanicked = true
 				ctx.Logger().Error("job panicked",
 					"tenant", string(tenant),
 					"job_id", string(j.ID),
@@ -342,36 +493,68 @@ func executeJob(ctx convCtx.Context, tenant convAuth.Tenant, j job) {
 			}
 		}()
 
-		if err := j.f(ctx); err != nil {
+		if jerr := j.f(jobCtx); jerr != nil {
+			jobErr = jerr
 			ctx.Logger().Error("job execution failed",
 				"tenant", string(tenant),
 				"job_id", string(j.ID),
-				"error", err.Error(),
+				"error", jerr.Error(),
 			)
 		}
 	}()
+	jobDuration := time.Since(startedAt)
 
-	// Compute next run time, advancing past any missed intervals
+	// Fast path: if the heartbeat already observed a confirmed loss, skip the advance.
+	if leaseLost.Load() {
+		ctx.Logger().Warn("skipping next_run_at advance: lease lost during execution",
+			"tenant", string(tenant),
+			"job_id", string(j.ID),
+		)
+		return
+	}
+
+	// Compute next run time, advancing past any missed intervals.
 	now := time.Now().UTC()
 	nextRunAt := j.NextRunAt.Add(j.RepeatEvery)
 	for !nextRunAt.After(now) {
 		nextRunAt = nextRunAt.Add(j.RepeatEvery)
 	}
 
-	// Update in-memory state
-	mut.Lock()
-	if tenantJobs, ok := jobs[tenant]; ok {
-		if memJob, ok := tenantJobs[j.ID]; ok {
-			memJob.NextRunAt = nextRunAt
-			tenantJobs[j.ID] = memJob
-		}
-	}
-	mut.Unlock()
-
-	// Update database state
+	// Persist the advance ONLY while we still hold a non-expired lease on this job. The object
+	// write and the ownership check commit in a single statement (UpdateGuarded), so a run
+	// whose lease was stolen or expired — even if that is only discovered as the write lands —
+	// cannot advance next_run_at; there is no window between confirming ownership and writing.
+	// UpdateGuarded is intentionally not ctx-cancellable, so it also lands (and decides
+	// ownership) correctly during scheduler shutdown. ErrLeaseLost ⇒ the new owner schedules.
 	updatedJob := j
 	updatedJob.NextRunAt = nextRunAt
-	if err := jobsDB.Tenant(tenant).Update(ctx, updatedJob); err != nil {
+	switch err := lock.UpdateGuarded(ctx, updatedJob); {
+	case err == nil:
+		mut.Lock()
+		if tenantJobs, ok := jobs[tenant]; ok {
+			if memJob, ok := tenantJobs[j.ID]; ok {
+				memJob.NextRunAt = nextRunAt
+				tenantJobs[j.ID] = memJob
+			}
+		}
+		mut.Unlock()
+
+		// Completion — emitted ONLY on genuine success (job returned nil, did not panic, and
+		// the guarded advance committed, i.e. we still owned the lease). Alerting keys off the
+		// ABSENCE of this log per (service, tenant, job); a failed/panicked job must NOT emit it.
+		if jobErr == nil && !jobPanicked {
+			ctx.Logger().Info("job execution completed",
+				"tenant", string(tenant),
+				"job_id", string(j.ID),
+				"duration_ms", jobDuration.Milliseconds(),
+			)
+		}
+	case errors.Is(err, convDB.ErrLeaseLost):
+		ctx.Logger().Warn("skipping next_run_at advance: lease not held at schedule write",
+			"tenant", string(tenant),
+			"job_id", string(j.ID),
+		)
+	default:
 		ctx.Logger().Error("failed to update job next run time in database",
 			"tenant", string(tenant),
 			"job_id", string(j.ID),

--- a/lib/job/job_lease_test.go
+++ b/lib/job/job_lease_test.go
@@ -1,0 +1,231 @@
+package job_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
+	convJob "github.com/sofmon/convention/lib/job"
+)
+
+// The heartbeat classifier: only a confirmed lost lease is fatal; transient
+// errors are retried.
+func TestRenewOutcome(t *testing.T) {
+	if !convJob.RenewOutcomeForTest(convDB.ErrLeaseLost) {
+		t.Fatal("ErrLeaseLost must be fatal (stop the job)")
+	}
+	if convJob.RenewOutcomeForTest(errors.New("transient db blip")) {
+		t.Fatal("a transient error must NOT be fatal (heartbeat must retry)")
+	}
+	if convJob.RenewOutcomeForTest(nil) {
+		t.Fatal("nil must not be fatal")
+	}
+}
+
+// Register is idempotent: a second registration over a nil-closure in-memory entry
+// (as syncJobsFromDB would leave) re-attaches the closure instead of erroring.
+func TestRegisterIdempotentReattachesClosure(t *testing.T) {
+	ctx := newCtx()
+	const jid convJob.JobID = "idem-job"
+	defer func() { _ = convJob.Unregister(ctx, testTenant, jid) }()
+
+	if err := convJob.InsertJobRowForTest(ctx, testTenant, jid, time.Now().Add(time.Hour), 5*time.Minute); err != nil {
+		t.Fatalf("insert job row: %v", err)
+	}
+	convJob.InjectNilClosureJobForTest(testTenant, jid, time.Now().Add(time.Hour), 5*time.Minute)
+
+	if present, hasClosure := convJob.MemJobClosureForTest(testTenant, jid); !present || hasClosure {
+		t.Fatalf("precondition: want present nil-closure entry, got present=%v hasClosure=%v", present, hasClosure)
+	}
+
+	err := convJob.Register(ctx, testTenant, jid, time.Now().Add(time.Hour), 5*time.Minute, func(convCtx.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("idempotent Register should not error, got: %v", err)
+	}
+
+	if present, hasClosure := convJob.MemJobClosureForTest(testTenant, jid); !present || !hasClosure {
+		t.Fatalf("after Register want closure attached, got present=%v hasClosure=%v", present, hasClosure)
+	}
+}
+
+// When the lease is lost mid-execution, executeJob must NOT advance/persist
+// next_run_at (the new owner is now responsible for scheduling).
+func TestExecuteJobSkipsAdvanceOnLeaseLoss(t *testing.T) {
+	base := newCtx()
+	ctx, dump := capturingCtx(base)
+	const jid convJob.JobID = "lease-loss-job"
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+
+	if err := convJob.InsertJobRowForTest(ctx, testTenant, jid, t0, time.Hour); err != nil {
+		t.Fatalf("insert job row: %v", err)
+	}
+	defer func() { _ = convJob.Unregister(ctx, testTenant, jid) }()
+
+	// Single in-memory connection so the heartbeat goroutine and the foreign steal
+	// share one database (Postgres needs no such pinning).
+	if err := convJob.PinSingleConnForTest(convDB.Vault(testVault), testTenant); err != nil {
+		t.Fatalf("pin conn: %v", err)
+	}
+
+	restore := convJob.SetLeaseForTest(10*time.Second, 10*time.Millisecond)
+	defer restore()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// The job body steals its own lock (as a foreign owner), then waits for
+		// cancellation — which the heartbeat triggers once its Renew sees the steal.
+		convJob.RunJobForTest(ctx, testTenant, jid, t0, time.Hour, func(jctx convCtx.Context) error {
+			if err := convJob.StealJobLockForTest(ctx, testTenant, jid, 10*time.Second); err != nil {
+				t.Errorf("steal: %v", err)
+				return err
+			}
+			<-jctx.Done()
+			return nil
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeJob did not return; lease-loss cancellation likely not wired")
+	}
+
+	got, ok, err := convJob.ReadJobRowNextRunForTest(ctx, testTenant, jid)
+	if err != nil || !ok {
+		t.Fatalf("read job row: ok=%v err=%v", ok, err)
+	}
+	if !got.Equal(t0) {
+		t.Fatalf("next_run_at advanced despite lease loss: got %v, want %v", got, t0)
+	}
+	if logged(dump(), "job execution completed") {
+		t.Fatalf("must NOT emit completion log when the lease was lost mid-run")
+	}
+}
+
+// A steal can land in the window between the heartbeat's last poll and the job
+// returning, leaving leaseLost false even though ownership is already gone. executeJob
+// must re-check ownership before advancing the schedule; otherwise it double-advances
+// next_run_at and emits a false completion (the deferred Unlock then reports
+// ErrLeaseLost). A long renew interval keeps the heartbeat from ever polling during the
+// fast job body, isolating exactly that race (distinct from the heartbeat-detected case
+// above).
+func TestExecuteJobRechecksLeaseBeforeAdvance(t *testing.T) {
+	base := newCtx()
+	ctx, dump := capturingCtx(base)
+	const jid convJob.JobID = "lease-recheck-job"
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+
+	if err := convJob.InsertJobRowForTest(ctx, testTenant, jid, t0, time.Hour); err != nil {
+		t.Fatalf("insert job row: %v", err)
+	}
+	defer func() { _ = convJob.Unregister(ctx, testTenant, jid) }()
+
+	if err := convJob.PinSingleConnForTest(convDB.Vault(testVault), testTenant); err != nil {
+		t.Fatalf("pin conn: %v", err)
+	}
+
+	// Long renew interval: the heartbeat never ticks during the fast job body, so
+	// leaseLost stays false and only the final ownership re-check can catch the steal.
+	restore := convJob.SetLeaseForTest(10*time.Second, 10*time.Minute)
+	defer restore()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// The job body steals its own lock (as a foreign owner) and returns at once,
+		// never waiting for cancellation — so the heartbeat has no chance to observe it.
+		convJob.RunJobForTest(ctx, testTenant, jid, t0, time.Hour, func(convCtx.Context) error {
+			if err := convJob.StealJobLockForTest(ctx, testTenant, jid, 10*time.Second); err != nil {
+				t.Errorf("steal: %v", err)
+			}
+			return nil
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeJob did not return")
+	}
+
+	got, ok, err := convJob.ReadJobRowNextRunForTest(ctx, testTenant, jid)
+	if err != nil || !ok {
+		t.Fatalf("read job row: ok=%v err=%v", ok, err)
+	}
+	if !got.Equal(t0) {
+		t.Fatalf("next_run_at advanced despite a steal the heartbeat never observed: got %v, want %v", got, t0)
+	}
+	if logged(dump(), "job execution completed") {
+		t.Fatalf("must NOT emit completion log for a run whose lease was stolen")
+	}
+}
+
+// Scheduler shutdown (Cancel()) cancels the parent context. A job that ignores
+// cancellation can run past its lease and be stolen; the final ownership check must
+// still reach the DB. If it used the cancelled parent context it would get
+// context.Canceled (treated as transient) before the DB call, and — because the schedule
+// Update does not honour ctx cancellation — would advance next_run_at and log completion
+// for a run it no longer owns.
+func TestExecuteJobRechecksLeaseDespiteSchedulerCancel(t *testing.T) {
+	base := newCtx()
+	capCtx, dump := capturingCtx(base)
+	ctx := capCtx
+	var cancelFn context.CancelFunc
+	ctx.Context, cancelFn = context.WithCancel(capCtx.Context)
+	defer cancelFn()
+
+	const jid convJob.JobID = "lease-cancel-job"
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+
+	if err := convJob.InsertJobRowForTest(ctx, testTenant, jid, t0, time.Hour); err != nil {
+		t.Fatalf("insert job row: %v", err)
+	}
+	defer func() { _ = convJob.Unregister(base, testTenant, jid) }()
+
+	if err := convJob.PinSingleConnForTest(convDB.Vault(testVault), testTenant); err != nil {
+		t.Fatalf("pin conn: %v", err)
+	}
+
+	// Long renew interval: the heartbeat never polls during the fast job body, so it never
+	// flips leaseLost — only the final ownership re-check can catch the steal.
+	restore := convJob.SetLeaseForTest(10*time.Second, 10*time.Minute)
+	defer restore()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		convJob.RunJobForTest(ctx, testTenant, jid, t0, time.Hour, func(convCtx.Context) error {
+			// Steal while the parent ctx is still live, then simulate Cancel() landing
+			// before executeJob's final ownership check.
+			if err := convJob.StealJobLockForTest(ctx, testTenant, jid, 10*time.Second); err != nil {
+				t.Errorf("steal: %v", err)
+			}
+			cancelFn()
+			return nil
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeJob did not return")
+	}
+
+	// Read with the uncancelled base ctx (the test ctx is now cancelled).
+	got, ok, err := convJob.ReadJobRowNextRunForTest(base, testTenant, jid)
+	if err != nil || !ok {
+		t.Fatalf("read job row: ok=%v err=%v", ok, err)
+	}
+	if !got.Equal(t0) {
+		t.Fatalf("next_run_at advanced after scheduler cancel despite a steal: got %v, want %v", got, t0)
+	}
+	if logged(dump(), "job execution completed") {
+		t.Fatalf("must NOT emit completion log for a stolen run during scheduler shutdown")
+	}
+}

--- a/lib/job/job_register_test.go
+++ b/lib/job/job_register_test.go
@@ -1,0 +1,153 @@
+package job_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
+	convJob "github.com/sofmon/convention/lib/job"
+)
+
+// capturingHandler is a thread-safe slog handler that records message strings
+// (the heartbeat goroutine logs concurrently, so it must be safe).
+type capturingHandler struct {
+	mu   *sync.Mutex
+	msgs *[]string
+}
+
+func (h capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.msgs = append(*h.msgs, r.Message)
+	return nil
+}
+func (h capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func capturingCtx(base convCtx.Context) (convCtx.Context, func() []string) {
+	var mu sync.Mutex
+	var msgs []string
+	logger := slog.New(capturingHandler{mu: &mu, msgs: &msgs})
+	return base.WithLogger(logger), func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(msgs))
+		copy(out, msgs)
+		return out
+	}
+}
+
+func logged(msgs []string, sub string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// A1: interval unchanged keeps the persisted NextRunAt (no clock reset on redeploy);
+// an interval change re-anchors NextRunAt to startAt and persists the new interval.
+// All times are in the real future so the background loop never executes the job.
+func TestRegisterIntervalReanchor(t *testing.T) {
+	ctx := newCtx()
+	const jid convJob.JobID = "interval-reanchor-job"
+	defer func() { _ = convJob.Unregister(ctx, testTenant, jid) }()
+
+	noop := func(convCtx.Context) error { return nil }
+	t1 := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	t2 := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	t3 := time.Now().Add(12 * time.Hour).UTC().Truncate(time.Second)
+
+	if err := convJob.Register(ctx, testTenant, jid, t1, time.Hour, noop); err != nil {
+		t.Fatalf("initial register: %v", err)
+	}
+	nr, re, ok, err := convJob.ReadJobRowForTest(ctx, testTenant, jid)
+	if err != nil || !ok {
+		t.Fatalf("read: ok=%v err=%v", ok, err)
+	}
+	if !nr.Equal(t1) || re != time.Hour {
+		t.Fatalf("initial: nextRunAt=%v repeatEvery=%v", nr, re)
+	}
+
+	// Same interval, different startAt -> persisted NextRunAt is kept.
+	if err := convJob.Register(ctx, testTenant, jid, t2, time.Hour, noop); err != nil {
+		t.Fatalf("same-interval register: %v", err)
+	}
+	nr, re, _, _ = convJob.ReadJobRowForTest(ctx, testTenant, jid)
+	if !nr.Equal(t1) {
+		t.Fatalf("same-interval must keep NextRunAt=%v, got %v", t1, nr)
+	}
+	if re != time.Hour {
+		t.Fatalf("same-interval repeatEvery=%v, want 1h", re)
+	}
+
+	// Changed (shortened) interval -> re-anchor to startAt + persist new interval.
+	if err := convJob.Register(ctx, testTenant, jid, t3, 30*time.Minute, noop); err != nil {
+		t.Fatalf("changed-interval register: %v", err)
+	}
+	nr, re, _, _ = convJob.ReadJobRowForTest(ctx, testTenant, jid)
+	if !nr.Equal(t3) {
+		t.Fatalf("changed-interval must re-anchor NextRunAt=%v, got %v", t3, nr)
+	}
+	if re != 30*time.Minute {
+		t.Fatalf("changed-interval repeatEvery=%v, want 30m", re)
+	}
+}
+
+// A2: the completion log fires on a clean run and is ABSENT on j.f error / panic.
+// (Lease-loss absence is asserted in TestExecuteJobSkipsAdvanceOnLeaseLoss.)
+func TestExecuteJobCompletionLog(t *testing.T) {
+	base := newCtx()
+	if err := convJob.PinSingleConnForTest(convDB.Vault(testVault), testTenant); err != nil {
+		t.Fatalf("pin conn: %v", err)
+	}
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+
+	run := func(jid convJob.JobID, fn convJob.JobFunc) []string {
+		if err := convJob.InsertJobRowForTest(base, testTenant, jid, t0, time.Hour); err != nil {
+			t.Fatalf("insert %s: %v", jid, err)
+		}
+		defer func() { _ = convJob.Unregister(base, testTenant, jid) }()
+		ctx, dump := capturingCtx(base)
+		convJob.RunJobForTest(ctx, testTenant, jid, t0, time.Hour, fn)
+		return dump()
+	}
+
+	t.Run("success emits completion", func(t *testing.T) {
+		msgs := run("completion-ok", func(convCtx.Context) error { return nil })
+		if !logged(msgs, "job execution completed") {
+			t.Fatalf("expected completion log; got %v", msgs)
+		}
+		if logged(msgs, "job execution failed") {
+			t.Fatalf("unexpected failure log")
+		}
+	})
+
+	t.Run("error suppresses completion", func(t *testing.T) {
+		msgs := run("completion-err", func(convCtx.Context) error { return errors.New("boom") })
+		if logged(msgs, "job execution completed") {
+			t.Fatalf("must NOT emit completion on error; got %v", msgs)
+		}
+		if !logged(msgs, "job execution failed") {
+			t.Fatalf("expected failure log; got %v", msgs)
+		}
+	})
+
+	t.Run("panic suppresses completion", func(t *testing.T) {
+		msgs := run("completion-panic", func(convCtx.Context) error { panic("boom") })
+		if logged(msgs, "job execution completed") {
+			t.Fatalf("must NOT emit completion on panic; got %v", msgs)
+		}
+		if !logged(msgs, "job panicked") {
+			t.Fatalf("expected panic log; got %v", msgs)
+		}
+	})
+}

--- a/lib/job/job_test.go
+++ b/lib/job/job_test.go
@@ -68,12 +68,13 @@ func TestRegisterAndUnregister(t *testing.T) {
 		t.Fatalf("Register failed: %v", err)
 	}
 
-	// Duplicate registration should fail
+	// Duplicate registration is now idempotent (re-attaches the closure / refreshes
+	// the schedule) rather than an error.
 	err = convJob.Register(ctx, testTenant, "test-job", time.Now().Add(1*time.Hour), 5*time.Minute, func(convCtx.Context) error {
 		return nil
 	})
-	if err == nil {
-		t.Fatal("expected error on duplicate Register")
+	if err != nil {
+		t.Fatalf("duplicate Register should be idempotent, got: %v", err)
 	}
 
 	err = convJob.Unregister(ctx, testTenant, "test-job")


### PR DESCRIPTION
## What changed

### Behavior
- A job whose holder is killed mid-execution (eviction, OOM, deploy) no longer stays dead. Its lock is now a heartbeat lease that a later run reclaims once it goes stale, so the schedule resumes on its own instead of freezing forever.
- The scheduler is no longer silent on lock contention: it logs when it skips a live lock, when it reclaims an expired one (naming the previous owner), and when it loses its lease mid-run.
- A successful run emits one `job execution completed` log carrying `tenant`, `job_id`, and `duration_ms`. Its absence per job is a clean "stuck or failing" signal for monitoring.
- `Register` is idempotent: re-registering an existing job re-attaches its closure and persists schedule changes, so callers no longer need an unregister+retry workaround to change an interval.
- An interval change applied through `Register` now takes effect on the next deploy (the next run is re-anchored); a plain redeploy with an unchanged interval does not reset the clock.

### Implementation
- `lib/db/lock.go`: opt-in `WithLease(d)` for `Lock` — steal-if-expired acquire via an alias upsert with the staleness cutoff computed in Go (so Postgres and SQLite behave identically), owner-safe `Unlock` (only the owner deletes), `Renew`, and `Stolen()`/`PreviousOwner()` accessors. Ownership is keyed on a **per-acquisition** token (the caller's description plus a unique suffix), so `Renew`/`Unlock` can never confuse two acquisitions that pass the same human-readable description; `PreviousOwner` strips the token back off for logging. The default `Lock()` path (no `WithLease`) is byte-for-byte unchanged.
- `lib/db/lock.go` (`UpdateGuarded`): persists the locked object only while this caller still owns the lease, with **no read-then-write window**. In one transaction it first renews the lease row with an owner-checked `UPDATE lock SET created_at=now WHERE id AND description=owner` (0 rows ⇒ `ErrLeaseLost`); that statement also holds the lease row's write lock, so a concurrent steal (the `ON CONFLICT DO UPDATE`) blocks until commit. The lease is renewed **once more right before commit**, so even a transaction that ran longer than the lease leaves a timestamp newer than a blocked waiter's cutoff (it called `Lock` before our commit) — that waiter cannot take over. The runtime write and the ownership claim are therefore mutually exclusive with stealing. Intentionally **not** ctx-cancellable, so it also lands and decides ownership during scheduler shutdown.
- `lib/db/update.go`: `ErrLeaseLost` sentinel.
- `lib/job/job.go`: `executeJob` acquires `WithLease(jobLease)` and renews from a heartbeat goroutine (transient renew errors retry; only a confirmed loss is fatal and cancels the job context, so a context-honouring job aborts early). The heartbeat keeps the lease alive across a long job body. It then advances `next_run_at` via `UpdateGuarded`, so the advance is atomically conditional on still owning the lease — `ErrLeaseLost` means another instance now schedules, and the run skips the advance and the completion log. Completion is emitted only when the guarded advance commits and the job neither errored nor panicked. `Register` re-attaches the closure on an existing in-memory entry (closing a `syncJobsFromDB` race) and persists schedule changes to the DB before mutating memory; on an interval change it re-anchors `NextRunAt` to `startAt`.
- Constants `jobLease = 90s`, `jobRenewInterval = 30s`. No schema change — the lease reuses the existing lock row (`id`, `created_at`, `description`); a stale row is reclaimed via the upsert.

### Tests
- `lib/db/lock_lease_test.go`: lease steal-when-expired, renew-prevents-steal, owner-safe unlock, renew-after-steal; two acquisitions sharing a description being distinct owners (the stale holder's `Renew`/`Unlock` report `ErrLeaseLost`); and `UpdateGuarded` — a live owner persists, a stolen holder gets `ErrLeaseLost` with the row untouched, and an expired-but-unstolen holder still persists (it is still the sole owner). Run on both Postgres and SQLite.
- `lib/job/job_lease_test.go`: `renewOutcome` classification; a heartbeat-observed lease loss skips the schedule advance; a steal the heartbeat never polled (long renew interval) is still caught at the guarded write, with no advance and no completion; the guarded write still reaches the DB after scheduler `Cancel()` (parent context cancelled mid-job), so a stolen run during shutdown neither advances nor completes; the completion log fires once on a clean run and is absent on `j.f` error, `j.f` panic, and lease loss.
- `lib/job/job_register_test.go`: idempotent `Register` re-attaches the closure; an interval change re-anchors `NextRunAt` while an unchanged interval preserves it; the persist-before-memory path leaves the in-memory schedule untouched when `Update` fails.

### Unchanged
- The default `Lock()` API and its `INSERT ... ON CONFLICT DO NOTHING` / `DELETE` semantics — only the new `WithLease` option alters behavior, so existing sticky-mutex callers keep never-steal semantics.
- No table schema or migration.

## Why

### Problem
A job's execution lock had no liveness mechanism: acquire was `INSERT ... ON CONFLICT DO NOTHING`, release was a `DELETE`. A holder killed before its deferred `Unlock` left the row behind permanently. `executeJob` then hit `if lock == nil { return }` and skipped the job silently on every subsequent tick — `next_run_at` frozen, no log line — with no recovery short of a manual row delete.

### Impact
Any consumer of `lib/job`: a single mid-run crash of a scheduler instance permanently and silently disables that job. Because nothing is logged and the schedule simply stops advancing, the failure is invisible until someone notices the downstream effect.

### Goal
A crashed holder's job lock is auto-reclaimed once stale, the scheduler is observable, and callers can change a job's interval without an unregister dance — with no schema change and no behavior change for non-job sticky-mutex callers.

### Why this approach
A heartbeat lease keyed on the existing `created_at` needs no migration and no new column, unlike explicit owner/expiry fields. The cutoff is computed in Go rather than via DB-specific time arithmetic so Postgres and SQLite behave identically (the suite runs on both). A generic background sweeper that bulk-deletes stale `*_lock` rows was considered and rejected: it cannot distinguish an orphan from a legitimately long-held sticky mutex and would risk deleting a live lock — so the lease is opt-in and only `lib/job` uses it, leaving sticky mutexes exactly as they were.

## How it was verified

### Automated checks
| Check | Command | Result |
|---|---|---|
| unit tests | `go test ./lib/db ./lib/job` | pass |
| race detector | `go test -race ./lib/db ./lib/job -run 'Test_Lock\|TestExecuteJob\|TestRenewOutcome\|TestRegister'` | pass |
| vet | `go vet ./lib/db ./lib/job` | pass |

### Behavior verified
- The lease tests reclaim a lock from an expired holder and confirm a still-renewing holder is not stolen from; the owner-safe unlock test confirms a non-owner cannot delete the lock.
- The completion-log tests confirm the success log fires exactly once on a clean run and is absent on every failure path (job error, panic, lease loss, Update failure).

### Not verified
- No CI runs on this repository, so the change is exercised only by the test suite above (Postgres + SQLite).
- The lease is wall-clock based and assumes NTP-synced clocks across scheduler instances; severe skew could shorten or lengthen the effective lease.

## Known limitations / risks
- The lease (`jobLease` / `jobRenewInterval`) is wall-clock based; a GC or scheduling pause exceeding the lease can cause a benign steal (logged as a lost lease, recovered on the next tick).
- Execution is at-least-once: if a job's lease is **stolen** mid-run (its heartbeat lapsed and another instance took over), the original run's guarded advance fails and the new owner schedules instead. Jobs must tolerate occasional re-runs — but the guard guarantees the schedule is never advanced by an instance that has lost ownership, so it cannot be double-advanced. (A lease that merely expired without being stolen is still the sole owner and advances normally — no wasted re-run.)
- Sticky-mutex orphans on the default `Lock()` path are deliberately not auto-reclaimed — that path is unchanged, and reclaiming it generically is unsafe (see the Why this approach section).
