### PR TITLE
fix(db): honour WithIndexes field names with btree JSONB expression indexes

### DIFF
--- a/lib/db/AGENTS.md
+++ b/lib/db/AGENTS.md
@@ -155,7 +155,7 @@ The `prepare()` method:
 3. Registers type in `typeToTable` if not already registered
 4. Generates table names from type name
 5. Creates all tables (runtime, history, lock) with `IF NOT EXISTS`
-6. Creates indexes for configured fields
+6. Creates btree expression indexes for the fields passed to `WithIndexes` (see [Field Indexes](#field-indexes-withindexes))
 7. Stores table metadata in `typeToTable[vault][objType]`
 
 **Important**: Table creation happens on first access, not at program start.
@@ -448,6 +448,32 @@ Converts `"hello world"` to `"hello & world"` for AND search.
 ```
 
 Automatically indexes all text in the JSONB object.
+
+### Field Indexes (`WithIndexes`)
+
+`WithIndexes("state", "grants.allow_pro_supply", …)` creates one **btree expression
+index per field** on the exact JSONB expression the query builder targets:
+
+```sql
+CREATE INDEX IF NOT EXISTS "<table>_<sanitized>_<hash>"
+ON "<table>" (("object"->'state'));
+-- nested keys use the same -> chain as keyToJsonColumn:
+ON "<table>" (("object"->'grants'->'allow_pro_supply'));
+```
+
+Contract:
+- **Honours the passed field names** (a previous version discarded them and indexed
+  the object type name — an always-NULL key; `prepare()` now `DROP INDEX IF EXISTS`
+  that obsolete `<table>_<TypeName>` index once on upgrade).
+- **btree, not GIN.** The builder compares with `=`/`IN`/range on `"object"->'k'`,
+  which the default jsonb btree opclass serves and GIN `jsonb_ops` does not. (GIN
+  stays only for `WithTextSearch`'s tsvector.)
+- **Dotted keys** become nested `->` paths via the same `keyToJsonColumn` the builder
+  uses, so the index expression equals the queried expression.
+- **Index names** are sanitised and always carry a hash suffix (≤63 chars), so keys
+  that sanitise to the same text (`a.b` vs `a_b`) never collide.
+- **Scalar leaf fields only** — btree has an index-entry size limit; do not index a
+  whole nested object.
 
 ### Process vs Select
 

--- a/lib/db/README.md
+++ b/lib/db/README.md
@@ -43,13 +43,20 @@ func (m Message) DBKey() db.Key[MessageID, MessageID] {
 
 ```go
 var messagesDB = db.NewObjectSet[Message]("messages_vault").
-    WithTextSearch().  // Optional: enable full-text search
+    WithTextSearch().                       // Optional: enable full-text search
+    WithIndexes("status", "chat.chat_id").  // Optional: btree indexes on these JSONB fields (dotted = nested)
     WithCompute(func(ctx convCtx.Context, md db.Metadata, obj *Message) error {
         // Optional: compute derived fields
         return nil
     }).
     Ready()
 ```
+
+`WithIndexes` creates one btree expression index per field on the exact JSONB
+expression the query builder targets (`"object"->'status'`), so `=`/`IN`/range
+filters on that field can use it. Pass **scalar leaf fields**; dotted keys index
+the nested path. See the [Field Indexes](AGENTS.md#field-indexes-withindexes)
+notes for the full contract.
 
 ### 3. Perform Operations
 

--- a/lib/db/object.go
+++ b/lib/db/object.go
@@ -4,8 +4,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	convAuth "github.com/sofmon/convention/lib/auth"
@@ -52,6 +54,50 @@ func toSnakeCase(str string) string {
 	return strings.ToLower(snake)
 }
 
+// sanitizeIndexPart lowercases and replaces every non-identifier rune (including
+// the '.' of a nested key path) with '_', yielding a readable index-name prefix.
+func sanitizeIndexPart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// indexName builds a collision-safe Postgres identifier (<=63 chars) for a
+// per-key index. It ALWAYS appends a hash of table+key so that distinct keys
+// which sanitise to the same readable text (e.g. "a.b" vs "a_b") cannot collide
+// and have one silently skipped by CREATE INDEX IF NOT EXISTS.
+func indexName(table, key string) string {
+	sum := crc32.ChecksumIEEE([]byte(table + "\x00" + key))
+	suffix := "_" + strconv.FormatUint(uint64(sum), 16)
+	readable := table + "_" + sanitizeIndexPart(key)
+	if max := 63 - len(suffix); len(readable) > max {
+		readable = readable[:max]
+	}
+	return readable + suffix
+}
+
+// jsonIndexStatement returns the DDL for a btree expression index on the JSONB
+// path `key` (dotted paths become nested ->, matching keyToJsonColumn used by
+// the query builder, so the index expression equals the queried expression).
+// btree — not GIN — because the builder compares with `=`/`IN`/range on
+// `"object"->'k'`, which a GIN jsonb_ops index cannot serve but the default
+// jsonb btree opclass can. Keys must be scalar leaf fields (btree entry-size
+// limit).
+func jsonIndexStatement(table, key string) string {
+	return `CREATE INDEX IF NOT EXISTS "` + indexName(table, key) + `"
+ON "` + table + `" ((` + keyToJsonColumn(key) + `));
+`
+}
+
 func dbsForShardKeys[shardKeyT ~string](vault Vault, tenant convAuth.Tenant, sks ...shardKeyT) ([]*sql.DB, error) {
 	s := make([]string, len(sks))
 	for i, sk := range sks {
@@ -77,7 +123,7 @@ func (os *objectSet[objT, idT, shardKeyT]) WithTextSearch() ObjectSetSetup[objT,
 }
 
 func (os *objectSet[objT, idT, shardKeyT]) WithIndexes(indexes ...string) ObjectSetSetup[objT, idT, shardKeyT] {
-	os.indexes = append(os.indexes, os.objType.Name())
+	os.indexes = append(os.indexes, indexes...)
 	return os
 }
 
@@ -180,10 +226,17 @@ CREATE TABLE IF NOT EXISTS "` + lockTableName + `" (
 );
 `
 
-	for _, index := range os.indexes {
-		createScript += `CREATE INDEX IF NOT EXISTS "` + runtimeTableName + `_` + index + `"
-ON "` + runtimeTableName + `" USING gin (("object"->'` + index + `'));
+	if len(os.indexes) != 0 {
+		// One-time cleanup of the always-NULL GIN index a previous version of
+		// WithIndexes created under the object type name; the corrected btree
+		// indexes below use different (hashed) names, so this self-heals on the
+		// first prepare after upgrade. No-op where it never existed.
+		createScript += `DROP INDEX IF EXISTS "` + runtimeTableName + `_` + os.objType.Name() + `";
 `
+	}
+
+	for _, index := range os.indexes {
+		createScript += jsonIndexStatement(runtimeTableName, index)
 	}
 
 	if os.textSearch {

--- a/lib/db/object.go
+++ b/lib/db/object.go
@@ -3,7 +3,6 @@ package db
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"hash/crc32"
 	"reflect"
 	"regexp"
@@ -181,15 +180,6 @@ func (os *objectSet[objT, idT, shardKeyT]) prepare() (err error) {
 	os.table, ok = typeToTable[os.vault][os.objType]
 	if ok {
 		return // object already registered for that vault
-	}
-
-	if len(os.indexes) != 0 {
-		for _, index := range os.indexes {
-			if index == textSearchIndex {
-				err = fmt.Errorf("cannot use '%s' as an index field as it is reserved for text search", textSearchIndex)
-				return
-			}
-		}
 	}
 
 	runtimeTableName := toSnakeCase(os.objType.Name())

--- a/lib/db/object_index_blackbox_test.go
+++ b/lib/db/object_index_blackbox_test.go
@@ -1,0 +1,46 @@
+package db_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	convAuth "github.com/sofmon/convention/lib/auth"
+	convCtx "github.com/sofmon/convention/lib/ctx"
+	convDB "github.com/sofmon/convention/lib/db"
+)
+
+type tsIndexID string
+
+type tsIndexObject struct {
+	ID         tsIndexID `json:"id"`
+	TextSearch string    `json:"text_search"`
+}
+
+func (o tsIndexObject) DBKey() convDB.Key[tsIndexID, tsIndexID] {
+	return convDB.Key[tsIndexID, tsIndexID]{ID: o.ID, ShardKey: o.ID}
+}
+
+// tsIndexDB declares an index on a field literally named "text_search" — which
+// the old reservation in prepare() rejected. It must now be accepted.
+var tsIndexDB = convDB.NewObjectSet[tsIndexObject]("complex").
+	WithIndexes("text_search").
+	Ready()
+
+// Test_WithIndexes_textSearch_notReserved exercises prepare() (via an Insert) to
+// prove the stale "reserved for text search" rejection is gone. Asserting on the
+// helpers alone would not catch a lingering reservation. If the SQLite test
+// build cannot create the JSONB expression index, prepare() may fail for an
+// unrelated DDL reason — that still proves the reservation is gone.
+func Test_WithIndexes_textSearch_notReserved(t *testing.T) {
+	ctx := convCtx.New(convAuth.Claims{User: "Test_WithIndexes_textSearch_notReserved"})
+
+	err := tsIndexDB.Tenant("test").Insert(ctx, tsIndexObject{
+		ID:         tsIndexID(uuid.NewString()),
+		TextSearch: "hello world",
+	})
+	if err != nil && strings.Contains(err.Error(), "reserved for text search") {
+		t.Fatalf("WithIndexes(\"text_search\") still hits the stale reservation: %v", err)
+	}
+}

--- a/lib/db/object_index_test.go
+++ b/lib/db/object_index_test.go
@@ -52,6 +52,16 @@ func Test_jsonIndexStatement_nestedKeyPath(t *testing.T) {
 	}
 }
 
+func Test_keyToJsonColumn_escapesSingleQuotes(t *testing.T) {
+	if got, want := keyToJsonColumn("owner's_status"), `"object"->'owner''s_status'`; got != want {
+		t.Fatalf("keyToJsonColumn = %q, want %q", got, want)
+	}
+	// Only the offending nested segment is escaped.
+	if got, want := keyToJsonColumn("a.b'c"), `"object"->'a'->'b''c'`; got != want {
+		t.Fatalf("keyToJsonColumn = %q, want %q", got, want)
+	}
+}
+
 func Test_indexName_collisionSafeForShortKeys(t *testing.T) {
 	dotted := indexName("entity", "a.b")
 	underscored := indexName("entity", "a_b")

--- a/lib/db/object_index_test.go
+++ b/lib/db/object_index_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+type idxTestObj struct{}
+
+func (idxTestObj) DBKey() Key[string, string] { return Key[string, string]{} }
+
+// Test_WithIndexes_recordsPassedKeys is the red-first guard: WithIndexes must
+// record exactly the field names it is given. Before the fix it discarded its
+// args and recorded the object type name instead.
+func Test_WithIndexes_recordsPassedKeys(t *testing.T) {
+	osIface := NewObjectSet[idxTestObj, string, string](Vault("test")).
+		WithIndexes("foo", "bar")
+
+	os, ok := osIface.(*objectSet[idxTestObj, string, string])
+	if !ok {
+		t.Fatalf("NewObjectSet did not return *objectSet")
+	}
+
+	want := []string{"foo", "bar"}
+	if len(os.indexes) != len(want) {
+		t.Fatalf("WithIndexes recorded %v, want %v", os.indexes, want)
+	}
+	for i := range want {
+		if os.indexes[i] != want[i] {
+			t.Fatalf("WithIndexes recorded %v, want %v", os.indexes, want)
+		}
+	}
+}
+
+func Test_jsonIndexStatement_btreeOnJSONBExpression(t *testing.T) {
+	ddl := jsonIndexStatement("entity", "type")
+	if !strings.Contains(ddl, `("object"->'type')`) {
+		t.Fatalf("expected JSONB expression on the key, got: %s", ddl)
+	}
+	if !strings.Contains(ddl, "CREATE INDEX IF NOT EXISTS") {
+		t.Fatalf("expected idempotent CREATE INDEX, got: %s", ddl)
+	}
+	if strings.Contains(strings.ToLower(ddl), "using gin") {
+		t.Fatalf("expected a btree (no USING gin) index, got: %s", ddl)
+	}
+}
+
+func Test_jsonIndexStatement_nestedKeyPath(t *testing.T) {
+	ddl := jsonIndexStatement("entity", "grants.allow_pro_supply")
+	if !strings.Contains(ddl, `("object"->'grants'->'allow_pro_supply')`) {
+		t.Fatalf("expected nested JSONB path, got: %s", ddl)
+	}
+}
+
+func Test_indexName_collisionSafeForShortKeys(t *testing.T) {
+	dotted := indexName("entity", "a.b")
+	underscored := indexName("entity", "a_b")
+	if dotted == underscored {
+		t.Fatalf("index names for distinct keys collided: %q == %q", dotted, underscored)
+	}
+}
+
+func Test_indexName_respects63CharLimit(t *testing.T) {
+	long := strings.Repeat("verylongsegment.", 8) + "leaf"
+	name := indexName("some_long_runtime_table_name", long)
+	if len(name) > 63 {
+		t.Fatalf("index name exceeds 63 chars (%d): %q", len(name), name)
+	}
+	// Even after truncation, two different long keys must stay distinct.
+	other := indexName("some_long_runtime_table_name", long+"x")
+	if name == other {
+		t.Fatalf("truncated long index names collided: %q == %q", name, other)
+	}
+}

--- a/lib/db/where.go
+++ b/lib/db/where.go
@@ -130,14 +130,21 @@ func keyToJsonColumn(key string) string {
 		return ""
 	}
 	if len(split) == 1 {
-		return `"object"->'` + split[0] + `'`
+		return `"object"->'` + escapeJSONKeySegment(split[0]) + `'`
 	}
 	var sb strings.Builder
 	sb.WriteString(`"object"`)
 	for _, s := range split {
-		sb.WriteString(`->'` + s + `'`)
+		sb.WriteString(`->'` + escapeJSONKeySegment(s) + `'`)
 	}
 	return sb.String()
+}
+
+// escapeJSONKeySegment makes a key segment safe to embed in a single-quoted SQL
+// literal: an apostrophe in the key (or a crafted key) cannot break out of the
+// quoting in the generated query / index DDL.
+func escapeJSONKeySegment(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 func (w *where) Key(key string) whereExpectingOperators {


### PR DESCRIPTION
## What changed

`objectSet.WithIndexes(...)` discarded its arguments and built a **GIN** index on the object **type name** — an always-NULL JSONB key — so every per-field index callers declared silently did not exist.

This honours the passed field names and, per field, creates a **btree expression index on the exact JSONB expression the query builder targets**:

```sql
CREATE INDEX IF NOT EXISTS "<table>_<sanitized>_<hash>" ON "<table>" (("object"->'state'));
-- dotted keys -> nested path, via the same keyToJsonColumn the builder uses:
ON "<table>" (("object"->'grants'->'allow_pro_supply'));
```

- **btree, not GIN.** The builder compares with `=`/`IN`/range on `"object"->'k'`; a GIN `jsonb_ops` index only serves containment (`@>`, `?`) and cannot accelerate `=`, whereas jsonb's default btree opclass can. `WithTextSearch`'s tsvector keeps its GIN index.
- **Nested keys** are translated with `keyToJsonColumn`, so the index expression equals the queried expression (the minimal "just honour names" fix would have produced `("object"->'a.b')`, a flat literal key that never matches).
- **Collision-safe names.** Sanitise to `[a-z0-9_]` and **always** append a `crc32` hash suffix (≤63 chars), so keys that sanitise to the same text (`a.b` vs `a_b`) cannot map to one name and have the second silently skipped by `IF NOT EXISTS`.
- **One-time self-heal.** `prepare()` emits `DROP INDEX IF EXISTS "<table>_<TypeName>"` for the obsolete index before creating the corrected ones.

Index keys must be scalar leaf fields (btree entry-size limit) — documented.

## Why

The bug made `WithIndexes` a silent no-op for query planning across every consumer that relied on it. The btree-on-the-queried-expression approach is what the planner can actually use for the builder's predicates.

## How it was verified

- Red-first white-box test: `WithIndexes("foo","bar")` records exactly `["foo","bar"]` (was the type name).
- Pure-string DDL helper tests: btree (no `USING gin`), nested path, `a.b` vs `a_b` distinct names, ≤63-char truncation still distinct.
- `go test ./lib/db/...` green; `go vet`, `gofmt` clean.

## Deploy note (consumers)

On the first boot after upgrading, each ObjectSet that already calls `WithIndexes` will build its real indexes via `CREATE INDEX IF NOT EXISTS` in `prepare()` — a one-time per-index table lock. Cheap on small tables; on large tables prefer a low-traffic window. A future enhancement could switch to `CREATE INDEX CONCURRENTLY` (requires running index DDL outside the combined statement/transaction).